### PR TITLE
Add block attributes

### DIFF
--- a/ast/attribute.go
+++ b/ast/attribute.go
@@ -1,0 +1,10 @@
+package ast
+
+// An attribute can be attached to block elements. They are specified as
+// {#id .classs key="value"} where quotes for values are mandatory, multiple
+// key/value pairs are separated by whitespace.
+type Attribute struct {
+	ID      []byte
+	Classes [][]byte
+	Attrs   map[string][]byte
+}

--- a/ast/node.go
+++ b/ast/node.go
@@ -45,6 +45,8 @@ type Container struct {
 
 	Literal []byte // Text contents of the leaf nodes
 	Content []byte // Markdown content of the block nodes
+
+	*Attribute // Block level attribute
 }
 
 // AsContainer returns itself as *Container
@@ -83,6 +85,8 @@ type Leaf struct {
 
 	Literal []byte // Text contents of the leaf nodes
 	Content []byte // Markdown content of the block nodes
+
+	*Attribute // Block level attribute
 }
 
 // AsContainer returns nil

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -446,7 +446,6 @@ func (r *Renderer) outOneOf(w io.Writer, outFirst bool, first string, second str
 func (r *Renderer) outOneOfCr(w io.Writer, outFirst bool, first string, second string) {
 	if outFirst {
 		r.cr(w)
-
 		r.outs(w, first)
 	} else {
 		r.outs(w, second)

--- a/parser/attribute.go
+++ b/parser/attribute.go
@@ -1,0 +1,116 @@
+package parser
+
+import (
+	"bytes"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+// attribute parses a (potential) block attribute and adds it to p.
+func (p *Parser) attribute(data []byte) []byte {
+	if len(data) < 3 {
+		return data
+	}
+	i := 0
+	if data[i] != '{' {
+		return data
+	}
+	i++
+
+	// last character must be a } otherwise it's not an attribute
+	end := skipUntilChar(data, i, '\n')
+	if data[end-1] != '}' {
+		return data
+	}
+
+	i = skipSpace(data, i)
+	b := &ast.Attribute{Attrs: make(map[string][]byte)}
+
+	esc := false
+	quote := false
+	trail := 0
+Loop:
+	for ; i < len(data); i++ {
+		switch data[i] {
+		case ' ', '\t', '\f', '\v':
+			if quote {
+				continue
+			}
+			chunk := data[trail+1 : i]
+			if len(chunk) == 0 {
+				trail = i
+				continue
+			}
+			switch {
+			case chunk[0] == '.':
+				b.Classes = append(b.Classes, chunk[1:])
+			case chunk[0] == '#':
+				b.ID = chunk[1:]
+			default:
+				k, v := keyValue(chunk)
+				if k != nil && v != nil {
+					b.Attrs[string(k)] = v
+				} else {
+					// this is illegal in an attribute
+					return data
+				}
+			}
+			trail = i
+		case '"':
+			if esc {
+				esc = !esc
+				continue
+			}
+			quote = !quote
+		case '\\':
+			esc = !esc
+		case '}':
+			if esc {
+				esc = !esc
+				continue
+			}
+			chunk := data[trail+1 : i]
+			if len(chunk) == 0 {
+				return data
+			}
+			switch {
+			case chunk[0] == '.':
+				b.Classes = append(b.Classes, chunk[1:])
+			case chunk[0] == '#':
+				b.ID = chunk[1:]
+			default:
+				k, v := keyValue(chunk)
+				if k != nil && v != nil {
+					b.Attrs[string(k)] = v
+				} else {
+					return data
+				}
+			}
+			i++
+			break Loop
+		default:
+			esc = false
+		}
+	}
+
+	p.attr = b
+	return data[i:]
+}
+
+// key="value" quotes are mandatory.
+func keyValue(data []byte) ([]byte, []byte) {
+	chunk := bytes.SplitN(data, []byte{'='}, 2)
+	if len(chunk) != 2 {
+		return nil, nil
+	}
+	key := chunk[0]
+	value := chunk[1]
+
+	if len(value) < 3 || len(key) == 0 {
+		return nil, nil
+	}
+	if value[0] != '"' || value[len(value)-1] != '"' {
+		return key, nil
+	}
+	return key, value[1 : len(value)-1]
+}

--- a/parser/attribute_test.go
+++ b/parser/attribute_test.go
@@ -1,0 +1,110 @@
+package parser
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+func TestBlockAttribute(t *testing.T) {
+	t.Parallel()
+	p := NewWithExtensions(CommonExtensions | Attributes)
+	tests := []struct {
+		data []byte
+		attr *ast.Attribute
+		left int
+	}{
+		// ok
+		{
+			data: []byte("{#myid}"),
+			attr: &ast.Attribute{ID: []byte("myid")},
+		},
+		{
+			data: []byte("{#myid #myid2}"),
+			attr: &ast.Attribute{ID: []byte("myid2")},
+		},
+		{
+			data: []byte("{.myclass}"),
+			attr: &ast.Attribute{
+				Classes: [][]byte{[]byte("myclass")},
+			},
+		},
+		{
+			data: []byte("{#myid .myclass}"),
+			attr: &ast.Attribute{
+				ID:      []byte("myid"),
+				Classes: [][]byte{[]byte("myclass")},
+			},
+		},
+		{
+			data: []byte("{#myid .myclass .myclass2}"),
+			attr: &ast.Attribute{
+				ID:      []byte("myid"),
+				Classes: [][]byte{[]byte("myclass")},
+			},
+		},
+		{
+			data: []byte(`{key="value"}`),
+			attr: &ast.Attribute{
+				Attrs: map[string][]byte{"key": []byte("value")},
+			},
+		},
+		{
+			data: []byte(`{key="value" #myid .myclass}`),
+			attr: &ast.Attribute{
+				ID:      []byte("myid"),
+				Classes: [][]byte{[]byte("myclass")},
+				Attrs:   map[string][]byte{"key": []byte("value")},
+			},
+		},
+		{
+			data: []byte(`{key="value" key2="value2" #myid #myid2 .myclass .myclass2}` + "\nmore"),
+			attr: &ast.Attribute{
+				ID:      []byte("myid2"),
+				Classes: [][]byte{[]byte("myclass"), []byte("myclass2")},
+				Attrs:   map[string][]byte{"key": []byte("value"), "key2": []byte("value2")},
+			},
+			left: 5,
+		},
+		// fails
+
+		// missing quote
+		{data: []byte(`{key=value" #myid .myclass}`)},
+		// too many spaces (should allow this eventually)
+		{data: []byte(`{key ="value"}`)},
+		// not block attribute
+		{data: []byte("hello")},
+	}
+	for i, test := range tests {
+		p.attr = nil
+		data := p.attribute(test.data)
+		if x := len(data); test.left > 0 && x != test.left {
+			t.Errorf("test %d, want %d of left data got %d", i, test.left, x)
+		}
+
+		if p.attr == nil && test.attr != nil {
+			t.Errorf("test %d, got nil for attribute", i)
+			continue
+		}
+		if p.attr == nil && test.attr == nil {
+			// ok
+			continue
+		}
+
+		if bytes.Compare(test.attr.ID, p.attr.ID) != 0 {
+			t.Errorf("test %d, got %q for ID, want %q", i, p.attr.ID, test.attr.ID)
+		}
+		for i, c := range test.attr.Classes {
+			if bytes.Compare(c, p.attr.Classes[i]) != 0 {
+				t.Errorf("test %d, got %q for class, want %q", i, p.attr.Classes[i], c)
+			}
+		}
+		if test.attr.Attrs != nil {
+			if !reflect.DeepEqual(test.attr.Attrs, p.attr.Attrs) {
+				t.Errorf("test %d, got %q for class, want %q", i, test.attr.Attrs, p.attr.Attrs)
+			}
+		}
+	}
+}

--- a/parser/block.go
+++ b/parser/block.go
@@ -98,6 +98,13 @@ func (p *Parser) block(data []byte) {
 
 	// parse out one block-level construct at a time
 	for len(data) > 0 {
+		// attributes that can be specific before a block element:
+		//
+		// {#id .class1 .class2 key="value"}
+		if p.extensions&Attributes != 0 {
+			data = p.attribute(data)
+		}
+
 		// prefixed heading:
 		//
 		// # Heading 1
@@ -259,6 +266,16 @@ func (p *Parser) block(data []byte) {
 
 func (p *Parser) addBlock(n ast.Node) ast.Node {
 	p.closeUnmatchedBlocks()
+
+	if p.attr != nil {
+		if c := n.AsContainer(); c != nil {
+			c.Attribute = p.attr
+		}
+		if l := n.AsLeaf(); l != nil {
+			l.Attribute = p.attr
+		}
+		p.attr = nil
+	}
 	return p.addChild(n)
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -36,6 +36,7 @@ const (
 	BackslashLineBreak                            // Translate trailing backslashes into line breaks
 	DefinitionLists                               // Parse definition lists
 	MathJax                                       // Parse MathJax
+	Attributes                                    // Block Attributes
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |
@@ -97,6 +98,9 @@ type Parser struct {
 	oldTip               ast.Node
 	lastMatchedContainer ast.Node // = doc
 	allClosed            bool
+
+	// Attributes are attached to block level elements.
+	attr *ast.Attribute
 }
 
 // New creates a markdown parser with CommonExtensions.


### PR DESCRIPTION
This adds the possibility to add block level attributes:

    {#id2}
    > line

When enabled to will generate (for HTML) an id="id2" in the openening
tag of the block quote:

    <blockquote id="id2">
    <p>line</p>
    </blockquote>

Only one block level attribute is allowed, if multiple are given only
the last one seen is applied, the rest is silently ignored.

The attributes are stored in *Parser and copy to the node in addBlock.
It's up to the renderer to use the attributes, the html renderer
currently only looks at the ID.

Signed-off-by: Miek Gieben <miek@miek.nl>