### PR TITLE
Table: add ast.Table in tableHeader

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -795,12 +795,8 @@ func finalizeCodeBlock(code *ast.CodeBlock) {
 }
 
 func (p *Parser) table(data []byte) int {
-	table := &ast.Table{}
-	p.addBlock(table)
 	i, columns := p.tableHeader(data)
 	if i == 0 {
-		p.tip = table.Parent
-		ast.RemoveFromTree(table)
 		return 0
 	}
 
@@ -836,6 +832,7 @@ func isBackslashEscaped(data []byte, i int) bool {
 	return backslashes&1 == 1
 }
 
+// tableHeaders parses the header. If recognized it will also add a table.
 func (p *Parser) tableHeader(data []byte) (size int, columns []ast.CellAlignFlags) {
 	i := 0
 	colCount := 1
@@ -938,6 +935,7 @@ func (p *Parser) tableHeader(data []byte) (size int, columns []ast.CellAlignFlag
 		return
 	}
 
+	p.addBlock(&ast.Table{})
 	p.addBlock(&ast.TableHead{})
 	p.tableRow(header, columns, true)
 	size = skipCharN(data, i, '\n', 1)


### PR DESCRIPTION
This removes the weird, add and then remove dance for the table node. It
also calls addBlock only when something is really going to be added.

Signed-off-by: Miek Gieben <miek@miek.nl>