### PR TITLE
Add ParserFunc

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -104,14 +104,15 @@ func (p *Parser) block(data []byte) {
 		if p.extensions&Attributes != 0 {
 			data = p.attribute(data)
 		}
-    
+
 		// user supplied parser function
 		if p.Opts.ParserHook != nil {
 			i := p.Opts.ParserHook(p, data)
 			if i > 0 {
 				data = data[i:]
+			}
 		}
-    
+
 		// prefixed heading:
 		//
 		// # Heading 1

--- a/parser/block.go
+++ b/parser/block.go
@@ -98,6 +98,14 @@ func (p *Parser) block(data []byte) {
 
 	// parse out one block-level construct at a time
 	for len(data) > 0 {
+		// user supplied parser function
+		if p.Opts.ParserHook != nil {
+			i := p.Opts.ParserHook(p, data)
+			if i > 0 {
+				data = data[i:]
+			}
+		}
+
 		// prefixed heading:
 		//
 		// # Heading 1

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,0 +1,11 @@
+package parser
+
+// ParserOptions is a collection of supplementary parameters tweaking
+// the behavior of various parts of parser.
+type ParserOptions struct {
+	ParserHook BlockFunc
+}
+
+// BlockFunc allows to registration of a parser function. If successful it
+// returns the number of bytes consumed.
+type BlockFunc func(p *Parser, data []byte) int

--- a/parser/options_test.go
+++ b/parser/options_test.go
@@ -1,0 +1,60 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+func blockTitleHook(p *Parser, data []byte) int {
+	// parse text between %%% and %%% and return it as a blockQuote.
+	i := 0
+	if len(data) < 3 {
+		return 0
+	}
+	if data[i] != '%' && data[i+1] != '%' && data[i+2] != '%' {
+		return 0
+	}
+
+	i += 3
+	// search for end.
+	for i < len(data) {
+		if data[i] == '%' && data[i+1] == '%' && data[i+2] == '%' {
+			break
+		}
+		i++
+	}
+	node := &ast.BlockQuote{}
+	p.addBlock(node)
+	p.block(data[4:i])
+	p.finalize(node)
+
+	return i + 3
+}
+
+func TestOptions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		data    []byte
+		wantAst ast.Node
+	}{
+		{
+			data: []byte(`
+%%%
+hallo
+%%%
+`),
+		},
+	}
+
+	p := New()
+	p.Opts = ParserOptions{ParserHook: blockTitleHook}
+
+	for _, test := range tests {
+		p.block(test.data)
+		ast.Print(os.Stdout, p.Doc)
+		fmt.Print("\n")
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -77,6 +77,8 @@ type Parser struct {
 	// the bottom will be used to fill in the link details.
 	ReferenceOverride ReferenceOverrideFunc
 
+	Opts ParserOptions
+
 	// after parsing, this is AST root of parsed markdown text
 	Doc ast.Node
 


### PR DESCRIPTION
Add a way to add custom parser functions that are called from the main
parser. This PR only adds a block level parsing option. It also requires
to make public: p.addChild, p.block and p.finalize.

With this in place it should be possible to parse a TOML title block
which will then be picked up the */renderer.

The test function in option_test.go is heavily inspired by function
`p.quote(data []byte) int`, (which does call addBlock and finalize).

We could potentially *always* call p.finalize and friends, but I'm not
sure if that make sense and in the case of a toml title block I don't
think I need/want that.

This avoids having a dependency on the toml Go library in this package.

Signed-off-by: Miek Gieben <miek@miek.nl>