### PR TITLE
BlockHook: better function signature

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -108,9 +108,18 @@ func (p *Parser) block(data []byte) {
 
 		// user supplied parser function
 		if p.Opts.ParserHook != nil {
-			i := p.Opts.ParserHook(p, data)
-			if i > 0 {
-				data = data[i:]
+			node, blockdata, consumed := p.Opts.ParserHook(data)
+			if consumed > 0 {
+				data = data[consumed:]
+
+				if node != nil {
+					p.addBlock(node)
+					if blockdata != nil {
+						p.block(blockdata)
+						p.finalize(node)
+					}
+				}
+				continue
 			}
 		}
 

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,11 +1,12 @@
 package parser
 
-// ParserOptions is a collection of supplementary parameters tweaking
-// the behavior of various parts of parser.
+import "github.com/gomarkdown/markdown/ast"
+
+// ParserOptions is a collection of supplementary parameters tweaking the behavior of various parts of the parser.
 type ParserOptions struct {
 	ParserHook BlockFunc
 }
 
 // BlockFunc allows to registration of a parser function. If successful it
-// returns the number of bytes consumed.
-type BlockFunc func(p *Parser, data []byte) int
+// returns an ast.Node, a buffer that should be parsed as a block and the the number of bytes consumed.
+type BlockFunc func(data []byte) (ast.Node, []byte, int)


### PR DESCRIPTION
This makes the function return the ast.Node, this also negates the need
to make addBlock, block, and finalize public or to give parser.Parser to
the function.

Fix the option_test.go to actually test things.

Signed-off-by: Miek Gieben <miek@miek.nl>