### PR TITLE
Mmark: add SpecialHeading

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ implements the following extensions:
     ```
     Will convert into `<h1 id="id3" class="myclass" fontsize="tiny">Header 1</h1>`.
 
+*   **Mmark Special Heading**. A heading stating with `#.`, this makes it a special header. This can
+    be used to typeset Abstract or Prefaces.
+
 ## Todo
 
 *   port https://github.com/russross/blackfriday/issues/348

--- a/ast/node.go
+++ b/ast/node.go
@@ -176,6 +176,7 @@ type Heading struct {
 	Level        int    // This holds the heading level number
 	HeadingID    string // This might hold heading ID, if present
 	IsTitleblock bool   // Specifies whether it's a title block
+	Special      []byte // We are a special heading (start with .#), contains header name
 }
 
 // HorizontalRule represents markdown horizontal rule node

--- a/block_test.go
+++ b/block_test.go
@@ -395,7 +395,7 @@ func TestPrefixHeaderMmarkExtension(t *testing.T) {
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li><p>Nested list</p>\n\n" +
 			"<h1 special=\"nested header\">Nested header</h1></li>\n</ul></li>\n</ul>\n",
 	}
-	doTestsBlock(t, tests, parser.Mmark)
+	doTestsBlock(t, tests, parser.MmarkSpecialHeading)
 }
 
 func TestUnderlineHeaders(t *testing.T) {

--- a/block_test.go
+++ b/block_test.go
@@ -376,6 +376,28 @@ func TestPrefixMultipleHeaderExtensions(t *testing.T) {
 	doTestsBlock(t, tests, parser.AutoHeadingIDs|parser.HeadingIDs)
 }
 
+func TestPrefixHeaderMmarkExtension(t *testing.T) {
+	t.Parallel()
+	var tests = []string{
+		".# Header 1\n",
+		`<h1 special="header 1">Header 1</h1>` + "\n",
+
+		".## Header 2\n",
+		"<p>.## Header 2</p>\n",
+
+		"Hello\n.# Header 1\nGoodbye\n",
+		"<p>Hello</p>\n\n<h1 special=\"header 1\">Header 1</h1>\n\n<p>Goodbye</p>\n",
+
+		"* List\n.# Header\n* List\n",
+		"<ul>\n<li><p>List</p>\n\n<h1 special=\"header\">Header</h1></li>\n\n<li><p>List</p></li>\n</ul>\n",
+
+		"*   List\n    * Nested list\n    .# Nested header\n",
+		"<ul>\n<li><p>List</p>\n\n<ul>\n<li><p>Nested list</p>\n\n" +
+			"<h1 special=\"nested header\">Nested header</h1></li>\n</ul></li>\n</ul>\n",
+	}
+	doTestsBlock(t, tests, parser.Mmark)
+}
+
 func TestUnderlineHeaders(t *testing.T) {
 	t.Parallel()
 	var tests = []string{

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -597,6 +597,9 @@ func (r *Renderer) headingEnter(w io.Writer, nodeData *ast.Heading) {
 	if nodeData.IsTitleblock {
 		attrs = append(attrs, `class="title"`)
 	}
+	if nodeData.Special != nil {
+		attrs = append(attrs, fmt.Sprintf(`special="%s"`, string(nodeData.Special)))
+	}
 	if nodeData.HeadingID != "" {
 		id := r.ensureUniqueHeadingID(nodeData.HeadingID)
 		if r.opts.HeadingIDPrefix != "" {

--- a/mmark_test.go
+++ b/mmark_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gomarkdown/markdown/html"
 	"github.com/gomarkdown/markdown/parser"
 )
 
@@ -18,22 +17,21 @@ func TestMmark(t *testing.T) {
 		t.Fatalf("failed to open file %q: %s", testfile, err)
 	}
 
-	ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart
-	parser := parser.NewWithExtensions(ext)
-	renderer := html.NewRenderer(html.RendererOptions{})
-
 	testdata := bytes.Split(data, []byte("---\n"))
 	if len(testdata)%2 != 0 {
 		t.Fatalf("odd test tuples: %d", len(testdata))
 	}
 	for i := 0; i < len(testdata); i += 2 {
+		ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart | parser.Mmark
+		parser := parser.NewWithExtensions(ext)
+
 		input := testdata[i]
 		want := testdata[i+1]
 
-		got := ToHTML([]byte(input), parser, renderer)
+		got := ToHTML([]byte(input), parser, nil)
 
 		if bytes.Compare(got, want) != 0 {
-			t.Errorf("want %s, got %s, for input %s", want, got, input)
+			t.Errorf("want %s, got %s, for input %q", want, got, input)
 		}
 	}
 }

--- a/mmark_test.go
+++ b/mmark_test.go
@@ -22,7 +22,7 @@ func TestMmark(t *testing.T) {
 		t.Fatalf("odd test tuples: %d", len(testdata))
 	}
 	for i := 0; i < len(testdata); i += 2 {
-		ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart | parser.Mmark
+		ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart | parser.MmarkSpecialHeading
 		parser := parser.NewWithExtensions(ext)
 
 		input := testdata[i]

--- a/parser/block.go
+++ b/parser/block.go
@@ -386,6 +386,9 @@ func (p *Parser) isPrefixSpecialHeading(data []byte) bool {
 	if data[1] != '#' {
 		return false
 	}
+	if data[2] == '#' { // we don't support level, so nack this.
+		return false
+	}
 
 	if p.extensions&SpaceHeadings != 0 {
 		if data[2] != ' ' {

--- a/parser/block.go
+++ b/parser/block.go
@@ -134,6 +134,15 @@ func (p *Parser) block(data []byte) {
 			continue
 		}
 
+		// prefixed special heading:
+		// (there are no levels.)
+		//
+		// .# Abstract
+		if p.isPrefixSpecialHeading(data) {
+			data = data[p.prefixSpecialHeading(data):]
+			continue
+		}
+
 		// block of preformatted HTML:
 		//
 		// <div>
@@ -357,6 +366,74 @@ func (p *Parser) prefixHeading(data []byte) int {
 		block := &ast.Heading{
 			HeadingID: id,
 			Level:     level,
+		}
+		block.Content = data[i:end]
+		p.addBlock(block)
+	}
+	return skip
+}
+
+func (p *Parser) isPrefixSpecialHeading(data []byte) bool {
+	if p.extensions|Mmark == 0 {
+		return false
+	}
+	if len(data) < 4 {
+		return false
+	}
+	if data[0] != '.' {
+		return false
+	}
+	if data[1] != '#' {
+		return false
+	}
+
+	if p.extensions&SpaceHeadings != 0 {
+		if data[2] != ' ' {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *Parser) prefixSpecialHeading(data []byte) int {
+	i := skipChar(data, 2, ' ') // ".#" skipped
+	end := skipUntilChar(data, i, '\n')
+	skip := end
+	id := ""
+	if p.extensions&HeadingIDs != 0 {
+		j, k := 0, 0
+		// find start/end of heading id
+		for j = i; j < end-1 && (data[j] != '{' || data[j+1] != '#'); j++ {
+		}
+		for k = j + 1; k < end && data[k] != '}'; k++ {
+		}
+		// extract heading id iff found
+		if j < end && k < end {
+			id = string(data[j+2 : k])
+			end = j
+			skip = k + 1
+			for end > 0 && data[end-1] == ' ' {
+				end--
+			}
+		}
+	}
+	for end > 0 && data[end-1] == '#' {
+		if isBackslashEscaped(data, end-1) {
+			break
+		}
+		end--
+	}
+	for end > 0 && data[end-1] == ' ' {
+		end--
+	}
+	if end > i {
+		if id == "" && p.extensions&AutoHeadingIDs != 0 {
+			id = sanitizeAnchorName(string(data[i:end]))
+		}
+		block := &ast.Heading{
+			HeadingID: id,
+			Special:   bytes.ToLower(data[i:end]),
+			Level:     1, // always level 1.
 		}
 		block.Content = data[i:end]
 		p.addBlock(block)
@@ -1389,8 +1466,8 @@ gatherlines:
 				sublist = raw.Len()
 			}
 
-		// is this a nested prefix heading?
-		case p.isPrefixHeading(chunk):
+			// is this a nested prefix heading?
+		case p.isPrefixHeading(chunk), p.isPrefixSpecialHeading(chunk):
 			// if the heading is not indented, it is not nested in the list
 			// and thus ends the list
 			if containsBlankLine && indent < 4 {
@@ -1602,7 +1679,7 @@ func (p *Parser) paragraph(data []byte) int {
 		}
 
 		// if there's a prefixed heading or a horizontal rule after this, paragraph is over
-		if p.isPrefixHeading(current) || p.isHRule(current) {
+		if p.isPrefixHeading(current) || p.isPrefixSpecialHeading(current) || p.isHRule(current) {
 			p.renderParagraph(data[:i])
 			return i
 		}

--- a/parser/block.go
+++ b/parser/block.go
@@ -374,7 +374,7 @@ func (p *Parser) prefixHeading(data []byte) int {
 }
 
 func (p *Parser) isPrefixSpecialHeading(data []byte) bool {
-	if p.extensions|Mmark == 0 {
+	if p.extensions|MmarkSpecialHeading == 0 {
 		return false
 	}
 	if len(data) < 4 {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,7 +38,7 @@ const (
 	MathJax                                       // Parse MathJax
 	OrderedListStart                              // Keep track of the first number used when starting an ordered list.
 	Attributes                                    // Block Attributes
-	Mmark                                         // Allow all Mmark syntax to be parsed, see mmark.nl/syntax.
+	MmarkSpecialHeading                           // Allow Mmark special headings to be parsed. See mmark.nl/syntax.
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,6 +38,7 @@ const (
 	MathJax                                       // Parse MathJax
 	OrderedListStart                              // Keep track of the first number used when starting an ordered list.
 	Attributes                                    // Block Attributes
+	Mmark                                         // Allow all Mmark syntax to be parsed, see mmark.nl/syntax.
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -1,3 +1,7 @@
 # Test 1
 ---
 <h1>Test 1</h1>
+---
+.# Test 2
+---
+<h1 special="test 2">Test 2</h1>


### PR DESCRIPTION
This adds detection for headers that start with `.#`. It adds the Mmark
extension, update the mmar test, adds some documentation.

I'm reusing the ast.Heading to have a maximum amount of code re-use.

Signed-off-by: Miek Gieben <miek@miek.nl>