### PR TITLE
Unify all Mmark extension under Mmark

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -395,7 +395,7 @@ func TestPrefixHeaderMmarkExtension(t *testing.T) {
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li><p>Nested list</p>\n\n" +
 			"<h1 special=\"nested header\">Nested header</h1></li>\n</ul></li>\n</ul>\n",
 	}
-	doTestsBlock(t, tests, parser.MmarkSpecialHeading)
+	doTestsBlock(t, tests, parser.Mmark)
 }
 
 func TestUnderlineHeaders(t *testing.T) {

--- a/mmark_test.go
+++ b/mmark_test.go
@@ -22,7 +22,7 @@ func TestMmark(t *testing.T) {
 		t.Fatalf("odd test tuples: %d", len(testdata))
 	}
 
-	ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart | parser.MmarkSpecialHeading | parser.MmarkMatters | parser.MmarkCaptions
+	ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart | parser.Mmark
 	for i := 0; i < len(testdata); i += 2 {
 		p := parser.NewWithExtensions(ext)
 

--- a/parser/block.go
+++ b/parser/block.go
@@ -232,7 +232,7 @@ func (p *Parser) block(data []byte) {
 		//
 		// A> The proof is too large to fit
 		// A> in the margin.
-		if p.extensions|MmarkAsides != 0 {
+		if p.extensions|Mmark != 0 {
 			if p.asidePrefix(data) > 0 {
 				data = data[p.aside(data):]
 				continue
@@ -304,8 +304,7 @@ func (p *Parser) block(data []byte) {
 		// document matters:
 		//
 		// {frontmatter}/{mainmatter}/{backmatter}
-		// check for Mmark extension once there.
-		if p.extensions&MmarkMatters != 0 {
+		if p.extensions&Mmark != 0 {
 			if i := p.documentMatter(data); i > 0 {
 				data = data[i:]
 				continue
@@ -397,7 +396,7 @@ func (p *Parser) prefixHeading(data []byte) int {
 }
 
 func (p *Parser) isPrefixSpecialHeading(data []byte) bool {
-	if p.extensions|MmarkSpecialHeading == 0 {
+	if p.extensions|Mmark == 0 {
 		return false
 	}
 	if len(data) < 4 {
@@ -904,7 +903,7 @@ func (p *Parser) fencedCodeBlock(data []byte, doRender bool) int {
 		}
 		codeBlock.Content = work.Bytes() // TODO: get rid of temp buffer
 
-		if p.extensions&MmarkCaptions == 0 {
+		if p.extensions&Mmark == 0 {
 			p.addBlock(codeBlock)
 			finalizeCodeBlock(codeBlock)
 			return beg
@@ -1212,7 +1211,7 @@ func (p *Parser) quote(data []byte) int {
 		beg = end
 	}
 
-	if p.extensions&MmarkCaptions == 0 {
+	if p.extensions&Mmark == 0 {
 		block := p.addBlock(&ast.BlockQuote{})
 		p.block(raw.Bytes())
 		p.finalize(block)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,11 +38,7 @@ const (
 	MathJax                                       // Parse MathJax
 	OrderedListStart                              // Keep track of the first number used when starting an ordered list.
 	Attributes                                    // Block Attributes
-	MmarkAsides                                   // Mmark asides paragraphs. See https://mmark.nl/syntax
-	MmarkCaptions                                 // Allow Mmark captions under code and quote blocks be parsed.
-	MmarkMatters                                  // Mmark document divisions, see https://mmark.nl/syntax#document-matters
-	MmarkReferenceIndex                           // Mmark cross references and indices. See https://mmark.nl/syntax#cross-references
-	MmarkSpecialHeading                           // Allow Mmark special headings to be parsed. See mmark.nl/syntax
+	Mmark                                         // Support Mmark syntax, see https://mmark.nl/syntax
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
 		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |
@@ -147,7 +143,7 @@ func NewWithExtensions(extension Extensions) *Parser {
 	p.inlineCallback['\\'] = escape
 	p.inlineCallback['&'] = entity
 	p.inlineCallback['!'] = maybeImage
-	if p.extensions&MmarkReferenceIndex != 0 {
+	if p.extensions&Mmark != 0 {
 		p.inlineCallback['('] = maybeShortRefOrIndex
 	}
 	p.inlineCallback['^'] = maybeInlineFootnote


### PR DESCRIPTION
This gets rid of the various Mmark* extension types.

Signed-off-by: Miek Gieben <miek@miek.nl>