### PR TITLE
Support includes

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -107,11 +107,11 @@ func (p *Parser) block(data []byte) {
 		}
 
 		if p.extensions&Mmark != 0 {
-			f := p.include
+			f := p.readInclude
 			path, address, consumed := p.isInclude(data)
 			if consumed == 0 {
 				path, address, consumed = p.isCodeInclude(data)
-				f = p.codeInclude
+				f = p.readCodeInclude
 			}
 			if consumed > 0 {
 				data = data[consumed:]

--- a/parser/block.go
+++ b/parser/block.go
@@ -106,6 +106,25 @@ func (p *Parser) block(data []byte) {
 			data = p.attribute(data)
 		}
 
+		if p.extensions&Mmark != 0 {
+			f := p.include
+			path, address, consumed := p.isInclude(data)
+			if consumed == 0 {
+				path, address, consumed = p.isCodeInclude(data)
+				f = p.codeInclude
+			}
+			if consumed > 0 {
+				data = data[consumed:]
+				old := p.cwd
+				p.cwd = updateWd(p.cwd, path)
+
+				data1 := f(path, address)
+				p.block(data1)
+
+				p.cwd = old
+			}
+		}
+
 		// user supplied parser function
 		if p.Opts.ParserHook != nil {
 			node, blockdata, consumed := p.Opts.ParserHook(data)

--- a/parser/include.go
+++ b/parser/include.go
@@ -1,0 +1,70 @@
+package parser
+
+import (
+	"path"
+	"path/filepath"
+)
+
+// updateWd updates the working directory. If new is an absolute
+// path we just use that, relative paths are taken relative of cur.
+func updateWd(cur, new string) string {
+	if path.IsAbs(new) {
+		return path.Dir(new)
+	}
+
+	return path.Dir(filepath.Join(cur, new))
+}
+
+// {{...}}
+func (p *Parser) isInclude(data []byte) (filename string, address []byte, consumed int) {
+	i := 0
+	if len(data) < 3 {
+		return "", nil, 0
+	}
+	if data[i] != '{' || data[i+1] != '{' {
+		return "", nil, 0
+	}
+
+	// find the end delimiter
+	i = skipUntilChar(data, i, '}')
+	if i+1 >= len(data) {
+		return "", nil, 0
+	}
+	if data[i+1] != '}' {
+		return "", nil, 0
+	}
+	return string(data[2:i]), nil, i + 1
+}
+
+func (p *Parser) include(file string, address []byte) []byte {
+	// p.cwd holds containing dir, already tailored to the path, means path.Base should give us the leaf.
+	fullPath := filepath.Join(p.cwd, path.Base(file))
+	if p.Opts.IncludeHook != nil {
+		return p.Opts.IncludeHook(fullPath, address)
+	}
+
+	return nil
+}
+
+// <{{...}}
+func (p *Parser) isCodeInclude(data []byte) (filename string, address []byte, consumed int) {
+	if len(data) < 3 {
+		return "", nil, 0
+	}
+	if data[0] != '<' {
+		return "", nil, 0
+	}
+	return p.isInclude(data[1:])
+}
+
+// codeInclude acts like include except the returned bytes are wrapped in a fenced code block.
+func (p *Parser) codeInclude(file string, address []byte) []byte {
+	data := p.include(file, address)
+	if data == nil {
+		return nil
+	}
+	// possible some fiddling to set the language etc.
+	data = append([]byte("```\n"), data...)
+	data = append(data, []byte("```")...)
+	return data
+}

--- a/parser/include.go
+++ b/parser/include.go
@@ -36,11 +36,11 @@ func (p *Parser) isInclude(data []byte) (filename string, address []byte, consum
 	return string(data[2:i]), nil, i + 1
 }
 
-func (p *Parser) include(file string, address []byte) []byte {
+func (p *Parser) readInclude(file string, address []byte) []byte {
 	// p.cwd holds containing dir, already tailored to the path, means path.Base should give us the leaf.
 	fullPath := filepath.Join(p.cwd, path.Base(file))
-	if p.Opts.IncludeHook != nil {
-		return p.Opts.IncludeHook(fullPath, address)
+	if p.Opts.ReadIncludeFn != nil {
+		return p.Opts.ReadIncludeFn(fullPath, address)
 	}
 
 	return nil
@@ -57,9 +57,9 @@ func (p *Parser) isCodeInclude(data []byte) (filename string, address []byte, co
 	return p.isInclude(data[1:])
 }
 
-// codeInclude acts like include except the returned bytes are wrapped in a fenced code block.
-func (p *Parser) codeInclude(file string, address []byte) []byte {
-	data := p.include(file, address)
+// readCodeInclude acts like include except the returned bytes are wrapped in a fenced code block.
+func (p *Parser) readCodeInclude(file string, address []byte) []byte {
+	data := p.readInclude(file, address)
 	if data == nil {
 		return nil
 	}

--- a/parser/include_test.go
+++ b/parser/include_test.go
@@ -16,13 +16,13 @@ func TestUpdateWd(t *testing.T) {
 
 func TestIsInclude(t *testing.T) {
 	p := New()
-	if name, _ := p.isInclude([]byte("{{foo}}")); name != "foo" {
+	if name, _, _ := p.isInclude([]byte("{{foo}}")); name != "foo" {
 		t.Errorf("want %s, got %s", "foo", name)
 	}
-	if name, _ := p.isInclude([]byte("{{foo}")); name != "" {
+	if name, _, _ := p.isInclude([]byte("{{foo}")); name != "" {
 		t.Errorf("want %s, got %s", "", name)
 	}
-	if name, _ := p.isInclude([]byte("{foo}")); name != "" {
+	if name, _, _ := p.isInclude([]byte("{foo}")); name != "" {
 		t.Errorf("want %s, got %s", "", name)
 	}
 }

--- a/parser/include_test.go
+++ b/parser/include_test.go
@@ -1,0 +1,28 @@
+package parser
+
+import "testing"
+
+func TestUpdateWd(t *testing.T) {
+	p := "/tmp"
+
+	if x := updateWd(p, "/new/foo"); x != "/new" {
+		t.Errorf("want %s, got %s", "/new", x)
+	}
+
+	if x := updateWd(p, "new/new"); x != "/tmp/new" {
+		t.Errorf("want %s, got %s", "/tmp/new", x)
+	}
+}
+
+func TestIsInclude(t *testing.T) {
+	p := New()
+	if name, _ := p.isInclude([]byte("{{foo}}")); name != "foo" {
+		t.Errorf("want %s, got %s", "foo", name)
+	}
+	if name, _ := p.isInclude([]byte("{{foo}")); name != "" {
+		t.Errorf("want %s, got %s", "", name)
+	}
+	if name, _ := p.isInclude([]byte("{foo}")); name != "" {
+		t.Errorf("want %s, got %s", "", name)
+	}
+}

--- a/parser/options.go
+++ b/parser/options.go
@@ -4,9 +4,15 @@ import "github.com/gomarkdown/markdown/ast"
 
 // ParserOptions is a collection of supplementary parameters tweaking the behavior of various parts of the parser.
 type ParserOptions struct {
-	ParserHook BlockFunc
+	ParserHook  BlockFunc
+	IncludeHook IncludeFunc
 }
 
 // BlockFunc allows to registration of a parser function. If successful it
 // returns an ast.Node, a buffer that should be parsed as a block and the the number of bytes consumed.
 type BlockFunc func(data []byte) (ast.Node, []byte, int)
+
+// IncludeFunc reads the file under path and returns the read bytes. If path is not absolute it is taken
+// relative to the currently parsed file. If this not set no data will be read from the filesystem.
+// address is the optional address specifier of which lines of the file to return.
+type IncludeFunc func(path string, address []byte) []byte

--- a/parser/options.go
+++ b/parser/options.go
@@ -4,15 +4,15 @@ import "github.com/gomarkdown/markdown/ast"
 
 // ParserOptions is a collection of supplementary parameters tweaking the behavior of various parts of the parser.
 type ParserOptions struct {
-	ParserHook  BlockFunc
-	IncludeHook IncludeFunc
+	ParserHook    BlockFunc
+	ReadIncludeFn ReadIncludeFunc
 }
 
 // BlockFunc allows to registration of a parser function. If successful it
 // returns an ast.Node, a buffer that should be parsed as a block and the the number of bytes consumed.
 type BlockFunc func(data []byte) (ast.Node, []byte, int)
 
-// IncludeFunc reads the file under path and returns the read bytes. If path is not absolute it is taken
+// ReadIncludeFunc reads the file under path and returns the read bytes. If path is not absolute it is taken
 // relative to the currently parsed file. If this not set no data will be read from the filesystem.
 // address is the optional address specifier of which lines of the file to return.
-type IncludeFunc func(path string, address []byte) []byte
+type ReadIncludeFunc func(path string, address []byte) []byte

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,6 +6,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -105,6 +106,9 @@ type Parser struct {
 
 	// Attributes are attached to block level elements.
 	attr *ast.Attribute
+
+	// Current working directory for relative includes.
+	cwd string
 }
 
 // New creates a markdown parser with CommonExtensions.
@@ -158,6 +162,9 @@ func NewWithExtensions(extension Extensions) *Parser {
 	if p.extensions&MathJax != 0 {
 		p.inlineCallback['$'] = math
 	}
+
+	p.cwd, _ = os.Getwd()
+
 	return &p
 }
 


### PR DESCRIPTION
This adds a IncludesHook that returns the byte to be read. Error
handling is completely left to the client. By default when there is no
includehook we return nil for bytes read.

Signed-off-by: Miek Gieben <miek@miek.nl>