### PR TITLE
Fix how classes are returned in block level attributes

### DIFF
--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -65,3 +65,11 @@ Caption: Shakespeare.
 <h1>Test Multiple Citations with modifier</h1>
 
 <p><cite class="suppressed">[RFC1034]</cite> <cite class="informative">[RFC1035]</cite></p>
+---
+{.myclass1 .myclass2}
+~~~
+code
+~~~
+---
+<pre><code class="myclass1 myclass2">code
+</code></pre>


### PR DESCRIPTION
Also export it, so it can be used directly in mmark/xml/renderer.go (I
had the exact copy of this code there)

Fixes #27

Signed-off-by: Miek Gieben <miek@miek.nl>