### PR TITLE
Make a String() function for AlignmentFlags

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -28,6 +28,19 @@ const (
 	TableAlignmentCenter = (TableAlignmentLeft | TableAlignmentRight)
 )
 
+func (a CellAlignFlags) String() string {
+	switch a {
+	case TableAlignmentLeft:
+		return "left"
+	case TableAlignmentRight:
+		return "right"
+	case TableAlignmentCenter:
+		return "center"
+	default:
+		return ""
+	}
+}
+
 // DocumentMatters holds the type of a {front,main,back}matter in the document
 type DocumentMatters int
 

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -358,20 +358,6 @@ func skipParagraphTags(para *ast.Paragraph) bool {
 	return tightOrTerm
 }
 
-// TODO: change this to be ast.CellAlignFlags.ToString()
-func cellAlignment(align ast.CellAlignFlags) string {
-	switch align {
-	case ast.TableAlignmentLeft:
-		return "left"
-	case ast.TableAlignmentRight:
-		return "right"
-	case ast.TableAlignmentCenter:
-		return "center"
-	default:
-		return ""
-	}
-}
-
 func (r *Renderer) out(w io.Writer, d []byte) {
 	r.lastOutputLen = len(d)
 	if r.disableTags > 0 {
@@ -807,7 +793,7 @@ func (r *Renderer) tableCell(w io.Writer, tableCell *ast.TableCell, entering boo
 	if tableCell.IsHeader {
 		openTag = "<th"
 	}
-	align := cellAlignment(tableCell.Align)
+	align := tableCell.Align.String()
 	if align != "" {
 		attrs = append(attrs, fmt.Sprintf(`align="%s"`, align))
 	}


### PR DESCRIPTION
Implement the TODO and a method `String()` that returns a string for
AlignmentFlags.

Pondered doing the same for Matters and CitationTypes, but those are
more renderer dependent (and not standard).

Signed-off-by: Miek Gieben <miek@miek.nl>