### PR TITLE
Fix off-by-one error in include parsing

### DIFF
--- a/parser/include.go
+++ b/parser/include.go
@@ -47,9 +47,8 @@ func (p *Parser) isInclude(data []byte) (filename string, address []byte, consum
 			return "", nil, 0
 		}
 		address = data[start:i]
-
 	}
-	return string(data[2:end]), address, i
+	return string(data[2:end]), address, i + 1
 }
 
 func (p *Parser) readInclude(file string, address []byte) []byte {


### PR DESCRIPTION
Of course, this happened. Fix off-by-one

Caught by mmark testing

Signed-off-by: Miek Gieben <miek@miek.nl>