### PR TITLE
Fix include testing

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -114,14 +114,15 @@ func (p *Parser) block(data []byte) {
 				f = p.readCodeInclude
 			}
 			if consumed > 0 {
-				data = data[consumed:]
 				old := p.cwd
 				p.cwd = updateWd(p.cwd, path)
 
-				data1 := f(path, address)
-				p.block(data1)
+				included := f(path, address)
+				p.block(included)
 
 				p.cwd = old
+				data = data[consumed+1:]
+				continue
 			}
 		}
 

--- a/parser/include.go
+++ b/parser/include.go
@@ -37,18 +37,20 @@ func (p *Parser) isInclude(data []byte) (filename string, address []byte, consum
 	if data[i] != '}' {
 		return "", nil, 0
 	}
+	filename = string(data[2:end])
 
 	if i+1 < len(data) && data[i+1] == '[' { // potential address specification
-		i++
-		start := i + 1
+		start := i + 2
 
-		i = skipUntilChar(data, start, ']')
-		if i >= len(data) {
+		end = skipUntilChar(data, start, ']')
+		if end >= len(data) {
 			return "", nil, 0
 		}
-		address = data[start:i]
+		address = data[start:end]
+		return filename, address, end + 1
 	}
-	return string(data[2:end]), address, i + 1
+
+	return filename, address, i + 1
 }
 
 func (p *Parser) readInclude(file string, address []byte) []byte {


### PR DESCRIPTION
Make the test table driven and fix bugs uncovered by the new test.
Mainly in the area of parsing the optional address specification between
block quotes.

Signed-off-by: Miek Gieben <miek@miek.nl>