### PR TITLE
Add quote block even without caption

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -1260,7 +1260,13 @@ func (p *Parser) quote(data []byte) int {
 		p.finalize(figure)
 
 		end += consumed
+
+		return end
 	}
+
+	block := p.addBlock(&ast.BlockQuote{})
+	p.block(raw.Bytes())
+	p.finalize(block)
 
 	return end
 }

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -45,6 +45,12 @@ Caption: Shakespeare.
 <figcaption>Shakespeare.</figcaption>
 </figure>
 ---
+> Bare
+---
+<blockquote>
+<p>Bare</p>
+</blockquote>
+---
 # Test Citations
 [@RFC1034]
 ---


### PR DESCRIPTION
This is the same fix as for #40, but for quote block.

Add bare quote test to testdata/mmark.test as well for this.

Signed-off-by: Miek Gieben <miek@miek.nl>