### PR TITLE
Add callout parsing

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -359,6 +359,13 @@ type CaptionFigure struct {
 	Container
 }
 
+// Callout is a node that can exist both in text (where it is an actual node) and in a code block.
+type Callout struct {
+	Leaf
+
+	ID []byte // number of this callout
+}
+
 func removeNodeFromArray(a []Node, node Node) []Node {
 	n := len(a)
 	for i := 0; i < n; i++ {

--- a/html/callouts.go
+++ b/html/callouts.go
@@ -1,0 +1,42 @@
+package html
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/gomarkdown/markdown/ast"
+	"github.com/mmarkdown/markdown/parser"
+)
+
+// EscapeHTMLCallouts writes html-escaped d to w. It escapes &, <, > and " characters, *but*
+// expands callouts <<N>> with the callout HTML, i.e. by calling r.callout() with a newly created
+// ast.Callout node.
+func (r *Renderer) EscapeHTMLCallouts(w io.Writer, d []byte) {
+	ld := len(d)
+Parse:
+	for i := 0; i < ld; i++ {
+		for _, comment := range r.opts.Comments {
+			if !bytes.HasPrefix(d[i:], comment) {
+				break
+			}
+
+			lc := len(comment)
+			if i+lc < ld {
+				if id, consumed := parser.IsCallout(d[i+lc:]); consumed > 0 {
+					// We have seen a callout
+					callout := &ast.Callout{ID: id}
+					r.callout(w, callout)
+					i += consumed + lc - 1
+					continue Parse
+				}
+			}
+		}
+
+		escSeq := htmlEscaper[d[i]]
+		if escSeq != nil {
+			w.Write(escSeq)
+		} else {
+			w.Write([]byte{d[i]})
+		}
+	}
+}

--- a/html/callouts.go
+++ b/html/callouts.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/gomarkdown/markdown/ast"
-	"github.com/mmarkdown/markdown/parser"
+	"github.com/gomarkdown/markdown/parser"
 )
 
 // EscapeHTMLCallouts writes html-escaped d to w. It escapes &, <, > and " characters, *but*

--- a/html/callouts_test.go
+++ b/html/callouts_test.go
@@ -1,0 +1,27 @@
+package html
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEscapeHTMLCallouts(t *testing.T) {
+	buf := &bytes.Buffer{}
+	code := []byte(`println("hello")
+more code //<<4>>
+bliep bliep
+`)
+	out := `println(&quot;hello&quot;)
+more code <span class="callout">4</span>
+bliep bliep
+`
+	opts := RendererOptions{}
+	opts.Comments = [][]byte{[]byte("//")}
+
+	r := NewRenderer(opts)
+	r.EscapeHTMLCallouts(buf, code)
+
+	if buf.String() != out {
+		t.Error("callout code block not correctly parsed")
+	}
+}

--- a/parser/callout.go
+++ b/parser/callout.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"bytes"
+	"strconv"
+)
+
+// IsCallout detects a callout in the following format: <<N>> Where N is a integer > 0.
+func IsCallout(data []byte) (id []byte, consumed int) {
+	if !bytes.HasPrefix(data, []byte("<<")) {
+		return nil, 0
+	}
+	start := 2
+	end := bytes.Index(data[start:], []byte(">>"))
+	if end < 0 {
+		return nil, 0
+	}
+
+	b := data[start : start+end]
+	b = bytes.TrimSpace(b)
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return nil, 0
+	}
+	if i <= 0 {
+		return nil, 0
+	}
+	return b, start + end + 2 // 2 for >>
+}

--- a/parser/callout_test.go
+++ b/parser/callout_test.go
@@ -1,0 +1,30 @@
+package parser
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestIsCallout(t *testing.T) {
+	tests := []struct {
+		data   []byte
+		number int
+	}{
+		// ok
+		{[]byte("<<4>>"), 4},
+		// fail
+		{[]byte("<<5a5>>"), 0},
+	}
+
+	for i, test := range tests {
+		bnum, read := IsCallout(test.data)
+		num, _ := strconv.Atoi(string(bnum))
+
+		if num != test.number {
+			t.Errorf("test %d, want %d, got %d", i, test.number, num)
+		}
+		if num > 0 && read != len(test.data) {
+			t.Errorf("test %d, want %d, got %d", i, len(test.data), read)
+		}
+	}
+}

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -606,6 +606,16 @@ const (
 // '<' when tags or autolinks are allowed
 func leftAngle(p *Parser, data []byte, offset int) (int, ast.Node) {
 	data = data[offset:]
+
+	if p.extensions&Mmark != 0 {
+		id, consumed := IsCallout(data)
+		if consumed > 0 {
+			node := &ast.Callout{}
+			node.ID = id
+			return consumed, node
+		}
+	}
+
 	altype, end := tagLength(data)
 	if size := p.inlineHTMLComment(data); size > 0 {
 		end = size


### PR DESCRIPTION
Add ast.Callout node that is detected in test and extra utils to parse
it in codeblock.

See https://mmark.nl/post/syntax/#callouts for what they are.

Signed-off-by: Miek Gieben <miek@miek.nl>