### PR TITLE
parser: remove logic to keep cwd

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -114,14 +114,8 @@ func (p *Parser) block(data []byte) {
 				f = p.readCodeInclude
 			}
 			if consumed > 0 {
-				old := p.cwd
-				p.cwd = updateWd(p.cwd, path)
-
 				included := f(path, address)
 				p.block(included)
-
-				p.cwd = old
-				data = data[consumed+1:]
 				continue
 			}
 		}

--- a/parser/include.go
+++ b/parser/include.go
@@ -55,10 +55,8 @@ func (p *Parser) isInclude(data []byte) (filename string, address []byte, consum
 }
 
 func (p *Parser) readInclude(file string, address []byte) []byte {
-	// p.cwd holds containing dir, already tailored to the path, means path.Base should give us the leaf.
-	fullPath := filepath.Join(p.cwd, path.Base(file))
 	if p.Opts.ReadIncludeFn != nil {
-		return p.Opts.ReadIncludeFn(fullPath, address)
+		return p.Opts.ReadIncludeFn(file, address)
 	}
 
 	return nil

--- a/parser/options.go
+++ b/parser/options.go
@@ -12,7 +12,7 @@ type ParserOptions struct {
 // returns an ast.Node, a buffer that should be parsed as a block and the the number of bytes consumed.
 type BlockFunc func(data []byte) (ast.Node, []byte, int)
 
-// ReadIncludeFunc reads the file under path and returns the read bytes. If path is not absolute it is taken
-// relative to the currently parsed file. If this not set no data will be read from the filesystem.
-// address is the optional address specifier of which lines of the file to return.
+// ReadIncludeFunc reads the file under path and returns the read bytes If this
+// not set no data will be read. address is the optional address specifier of
+// which lines of the file to return.
 type ReadIncludeFunc func(path string, address []byte) []byte

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,7 +6,6 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -106,9 +105,6 @@ type Parser struct {
 
 	// Attributes are attached to block level elements.
 	attr *ast.Attribute
-
-	// Current working directory for relative includes.
-	cwd string
 }
 
 // New creates a markdown parser with CommonExtensions.
@@ -162,8 +158,6 @@ func NewWithExtensions(extension Extensions) *Parser {
 	if p.extensions&MathJax != 0 {
 		p.inlineCallback['$'] = math
 	}
-
-	p.cwd, _ = os.Getwd()
 
 	return &p
 }


### PR DESCRIPTION
This removes the logic for CWD tracking and leaves it up to the user
of the library to do this themselves.

Fixes: #50

Signed-off-by: Miek Gieben <miek@miek.nl>