### PR TITLE
Include: take2

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -114,8 +114,10 @@ func (p *Parser) block(data []byte) {
 				f = p.readCodeInclude
 			}
 			if consumed > 0 {
-				included := f(path, address)
+				included := f(p.includeStack.Last(), path, address)
+				p.includeStack.Push(path)
 				p.block(included)
+				p.includeStack.Pop()
 				data = data[consumed:]
 				continue
 			}

--- a/parser/include.go
+++ b/parser/include.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"path"
+	"path/filepath"
 )
 
 // isInclude parses {{...}}[...], that contains a path between the {{, the [...] syntax contains
@@ -43,9 +44,9 @@ func (p *Parser) isInclude(data []byte) (filename string, address []byte, consum
 	return filename, address, i + 1
 }
 
-func (p *Parser) readInclude(file string, address []byte) []byte {
+func (p *Parser) readInclude(from, file string, address []byte) []byte {
 	if p.Opts.ReadIncludeFn != nil {
-		return p.Opts.ReadIncludeFn(file, address)
+		return p.Opts.ReadIncludeFn(from, file, address)
 	}
 
 	return nil
@@ -67,15 +68,15 @@ func (p *Parser) isCodeInclude(data []byte) (filename string, address []byte, co
 }
 
 // readCodeInclude acts like include except the returned bytes are wrapped in a fenced code block.
-func (p *Parser) readCodeInclude(file string, address []byte) []byte {
-	data := p.readInclude(file, address)
+func (p *Parser) readCodeInclude(from, file string, address []byte) []byte {
+	data := p.readInclude(from, file, address)
 	if data == nil {
 		return nil
 	}
 	ext := path.Ext(file)
 	buf := &bytes.Buffer{}
 	buf.Write([]byte("```"))
-	if ext != "" {
+	if ext != "" { // starts with a dot
 		buf.WriteString(" " + ext[1:] + "\n")
 	} else {
 		buf.WriteByte('\n')
@@ -83,4 +84,42 @@ func (p *Parser) readCodeInclude(file string, address []byte) []byte {
 	buf.Write(data)
 	buf.WriteString("```\n")
 	return buf.Bytes()
+}
+
+// incStack hold the current stack of chained includes. Each value is the containing
+// path of the file being parsed.
+type incStack struct {
+	stack []string
+}
+
+func newIncStack() *incStack {
+	return &incStack{stack: []string{}}
+}
+
+// Push updates i with new.
+func (i *incStack) Push(new string) {
+	if path.IsAbs(new) {
+		i.stack = append(i.stack, path.Dir(new))
+		return
+	}
+	last := ""
+	if len(i.stack) > 0 {
+		last = i.stack[len(i.stack)-1]
+	}
+	i.stack = append(i.stack, path.Dir(filepath.Join(last, new)))
+}
+
+// Pop pops the last value.
+func (i *incStack) Pop() {
+	if len(i.stack) == 0 {
+		return
+	}
+	i.stack = i.stack[:len(i.stack)-1]
+}
+
+func (i *incStack) Last() string {
+	if len(i.stack) == 0 {
+		return ""
+	}
+	return i.stack[len(i.stack)-1]
 }

--- a/parser/include_test.go
+++ b/parser/include_test.go
@@ -90,3 +90,14 @@ func TestIsCodeInclude(t *testing.T) {
 		}
 	}
 }
+
+func TestPush(t *testing.T) {
+	i := newIncStack()
+	if i.Push("/new/foo"); i.stack[0] != "/new" {
+		t.Errorf("want %s, got %s", "/new", i.stack[0])
+	}
+
+	if i.Push("new/new"); i.stack[1] != "/new/new" {
+		t.Errorf("want %s, got %s", "/new/new", i.stack[1])
+	}
+}

--- a/parser/include_test.go
+++ b/parser/include_test.go
@@ -101,3 +101,14 @@ func TestPush(t *testing.T) {
 		t.Errorf("want %s, got %s", "/new/new", i.stack[1])
 	}
 }
+
+func TestPop(t *testing.T) {
+	i := newIncStack()
+	if i.Push("/new/foo"); i.stack[0] != "/new" {
+		t.Errorf("want %s, got %s", "/new", i.stack[0])
+	}
+	i.Pop()
+	if len(i.stack) != 0 {
+		t.Errorf("after pop, want %d, got %d", 0, len(i.stack))
+	}
+}

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,6 +1,8 @@
 package parser
 
-import "github.com/gomarkdown/markdown/ast"
+import (
+	"github.com/gomarkdown/markdown/ast"
+)
 
 // ParserOptions is a collection of supplementary parameters tweaking the behavior of various parts of the parser.
 type ParserOptions struct {
@@ -12,7 +14,8 @@ type ParserOptions struct {
 // returns an ast.Node, a buffer that should be parsed as a block and the the number of bytes consumed.
 type BlockFunc func(data []byte) (ast.Node, []byte, int)
 
-// ReadIncludeFunc reads the file under path and returns the read bytes If this
-// not set no data will be read. address is the optional address specifier of
-// which lines of the file to return.
-type ReadIncludeFunc func(path string, address []byte) []byte
+// ReadIncludeFunc should read the file under path and returns the read bytes,
+// from will be set to the name of the current file being parsed. Initially
+// this will be empty. address is the optional address specifier of which lines
+// of the file to return. If this function is not set no data will be read.
+type ReadIncludeFunc func(from, path string, address []byte) []byte

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -105,6 +105,8 @@ type Parser struct {
 
 	// Attributes are attached to block level elements.
 	attr *ast.Attribute
+
+	includeStack *incStack
 }
 
 // New creates a markdown parser with CommonExtensions.
@@ -119,12 +121,13 @@ func New() *Parser {
 // NewWithExtensions creates a markdown parser with given extensions.
 func NewWithExtensions(extension Extensions) *Parser {
 	p := Parser{
-		refs:       make(map[string]*reference),
-		maxNesting: 16,
-		insideLink: false,
-		Doc:        &ast.Document{},
-		extensions: extension,
-		allClosed:  true,
+		refs:         make(map[string]*reference),
+		maxNesting:   16,
+		insideLink:   false,
+		Doc:          &ast.Document{},
+		extensions:   extension,
+		allClosed:    true,
+		includeStack: newIncStack(),
 	}
 	p.tip = p.Doc
 	p.oldTip = p.Doc


### PR DESCRIPTION
Bring back keeping a stack of included file because don't assume a CWD for the process.

The user of this lib still needs to do a little dance to get the correct path, keeping in mind the CWD, initial file (absolute or not). I now have this:

Fixes #54
~~~
// The initial file we are working on, empty for stdin and adjusted is we
// we have an absolute or relative file.
type Initial string

func NewInitial(s string) Initial {
	if path.IsAbs(s) {
		return Initial(path.Dir(s))
	}

	cwd, _ := os.Getwd()
	if s == "" {
		return Initial(cwd)
	}
	return Initial(path.Dir(filepath.Join(cwd, s)))
}

// path returns the full path we should use according to from, file and initial.
func (i Initial) path(from, file string) string {
	if path.IsAbs(file) {
		return file
	}
	if path.IsAbs(from) {
		filepath.Join(from, file)
	}

	f1 := filepath.Join(string(i), from)

	return filepath.Join(f1, file)
}
~~~