### PR TITLE
Mark tests: remove whitespace hack

### DIFF
--- a/mmark_test.go
+++ b/mmark_test.go
@@ -31,12 +31,6 @@ func TestMmark(t *testing.T) {
 
 		got := ToHTML([]byte(input), p, nil)
 
-		// make whitespace more visible
-		got = bytes.Replace(got, []byte(" "), []byte("_"), -1)
-		want = bytes.Replace(want, []byte(" "), []byte("_"), -1)
-		got = bytes.Replace(got, []byte("\n"), []byte("_\n"), -1)
-		want = bytes.Replace(want, []byte("\n"), []byte("_\n"), -1)
-
 		if bytes.Compare(got, want) != 0 {
 			t.Errorf("want (%d bytes) %s, got (%d bytes) %s, for input %q", len(want), want, len(got), got, input)
 		}

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -24,9 +24,9 @@ println("hi")
 Caption: This *is* a
   caption.
 ---
-<h1>Test_Code_Captions</h1>
+<h1>Test Code Captions</h1>
 <figure>
-<pre><code_class="language-go">println(&quot;hi&quot;)
+<pre><code class="language-go">println(&quot;hi&quot;)
 </code></pre>
 <figcaption>This <em>is</em> a
   caption.</figcaption>
@@ -54,7 +54,7 @@ Caption: Shakespeare.
 # Test Citations
 [@RFC1034]
 ---
-<h1>Test_Citations</h1>
+<h1>Test Citations</h1>
 
 <p><cite class="informative">[RFC1034]</cite></p>
 ---


### PR DESCRIPTION
Doesn't add anything and actually created testcases that were wrong.

Signed-off-by: Miek Gieben <miek@miek.nl>