### PR TITLE
Add uniq ID to indices

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -373,6 +373,7 @@ type Index struct {
 	Primary bool
 	Item    []byte
 	Subitem []byte
+	ID      []byte // number of the index
 }
 
 func removeNodeFromArray(a []Node, node Node) []Node {

--- a/ast/node.go
+++ b/ast/node.go
@@ -373,7 +373,7 @@ type Index struct {
 	Primary bool
 	Item    []byte
 	Subitem []byte
-	ID      []byte // number of the index
+	ID      int // number of the index
 }
 
 func removeNodeFromArray(a []Node, node Node) []Node {

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -871,7 +871,7 @@ func (r *Renderer) callout(w io.Writer, node *ast.Callout) {
 
 func (r *Renderer) index(w io.Writer, node *ast.Index) {
 	// there is no in-text representation.
-	attr := []string{`class="index"`, `id="` + string(node.ID) + `"`}
+	attr := []string{`class="index"`, fmt.Sprintf(`id="%d"`, node.ID)}
 	r.outTag(w, "<span", attr)
 	r.outs(w, "</span>")
 }

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -871,6 +871,9 @@ func (r *Renderer) callout(w io.Writer, node *ast.Callout) {
 
 func (r *Renderer) index(w io.Writer, node *ast.Index) {
 	// there is no in-text representation.
+	attr := []string{`class="index"`, `id="` + string(node.ID) + `"`}
+	r.outTag(w, "<span", attr)
+	r.outs(w, "</span>")
 }
 
 // RenderNode renders a markdown node to HTML

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -92,6 +92,7 @@ type Parser struct {
 	nesting        int
 	maxNesting     int
 	insideLink     bool
+	indexCnt       int // incremented after every index
 
 	// Footnotes need to be ordered as well as available to quickly check for
 	// presence. If a ref is also a footnote, it's stored both in refs and here

--- a/parser/ref.go
+++ b/parser/ref.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"bytes"
-	"strconv"
 
 	"github.com/gomarkdown/markdown/ast"
 )
@@ -64,7 +63,7 @@ func maybeShortRefOrIndex(p *Parser, data []byte, offset int) (int, ast.Node) {
 
 		idx := &ast.Index{}
 
-		idx.ID = []byte(strconv.Itoa(p.indexCnt))
+		idx.ID = p.indexCnt
 		p.indexCnt++
 
 		idx.Primary = data[start] == '!'

--- a/parser/ref.go
+++ b/parser/ref.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"strconv"
 
 	"github.com/gomarkdown/markdown/ast"
 )
@@ -60,7 +61,12 @@ func maybeShortRefOrIndex(p *Parser, data []byte, offset int) (int, ast.Node) {
 		if len(data[start:i]) < 1 {
 			return 0, nil
 		}
+
 		idx := &ast.Index{}
+
+		idx.ID = []byte(strconv.Itoa(p.indexCnt))
+		p.indexCnt++
+
 		idx.Primary = data[start] == '!'
 		buf := data[start:i]
 

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -87,9 +87,9 @@ code
 ---
 <h1>Index</h1>
 
-<p>
-
-</p>
+<p><span class="index" id="0"></span>
+<span class="index" id="1"></span>
+<span class="index" id="2"></span></p>
 ---
 # Cross ref
 Look at (#basics)


### PR DESCRIPTION
To allow linking to indices by giving them an ID; without it an index
can not refer back to the actual index item from main index at the end
of the document.

Signed-off-by: Miek Gieben <miek@miek.nl>