### PR TITLE
Cross reference: prepend '#'

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -907,7 +907,7 @@ func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.Wal
 	case *ast.Link:
 		r.link(w, node, entering)
 	case *ast.CrossReference:
-		link := &ast.Link{Destination: node.Destination}
+		link := &ast.Link{Destination: append([]byte("#"), node.Destination...)}
 		r.link(w, link, entering)
 	case *ast.Citation:
 		r.citation(w, node)

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -96,4 +96,4 @@ Look at (#basics)
 +++
 <h1>Cross ref</h1>
 
-<p>Look at <a href="basics"></a></p>
+<p>Look at <a href="#basics"></a></p>


### PR DESCRIPTION
The link is local (by definition) add '#' to mark it as such.

Signed-off-by: Miek Gieben <miek@miek.nl>