### PR TITLE
Table: parse table footers

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -334,8 +334,8 @@ type TableCell struct {
 	Align    CellAlignFlags // This holds the value for align attribute
 }
 
-// TableHead represents markdown table head node
-type TableHead struct {
+// TableHeader represents markdown table head node
+type TableHeader struct {
 	Container
 }
 
@@ -346,6 +346,11 @@ type TableBody struct {
 
 // TableRow represents markdown table row node
 type TableRow struct {
+	Container
+}
+
+// TableFooter represents markdown table foot node
+type TableFooter struct {
 	Container
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -1206,6 +1206,9 @@ func TestTable(t *testing.T) {
 
 		"a|b\\|c|d\n---|---|---\nf|g\\|h|i\n",
 		"<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b|c</th>\n<th>d</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>f</td>\n<td>g|h</td>\n<td>i</td>\n</tr>\n</tbody>\n</table>\n",
+
+		"a|b\\|c|d\n---|---|---\nf|g\\|h|i\n===|===|===\nj|k|l|m\n",
+		"<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b|c</th>\n<th>d</th>\n</tr>\n</thead>\n\n<tbody>\n<tr>\n<td>f</td>\n<td>g|h</td>\n<td>i</td>\n</tr>\n</tbody>\n\n<tfoot>\n<tr>\n<td>j</td>\n<td>k</td>\n<td>l</td>\n</tr>\n</tfoot>\n</table>\n",
 	}
 	doTestsBlock(t, tests, parser.Tables)
 }

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -945,12 +945,14 @@ func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.Wal
 		r.outOneOfCr(w, entering, tag, "</table>")
 	case *ast.TableCell:
 		r.tableCell(w, node, entering)
-	case *ast.TableHead:
+	case *ast.TableHeader:
 		r.outOneOfCr(w, entering, "<thead>", "</thead>")
 	case *ast.TableBody:
 		r.tableBody(w, node, entering)
 	case *ast.TableRow:
 		r.outOneOfCr(w, entering, "<tr>", "</tr>")
+	case *ast.TableFooter:
+		r.outOneOfCr(w, entering, "<tfoot>", "</tfoot>")
 	case *ast.Math:
 		r.outOneOf(w, true, `<span class="math inline">\(`, `\)</span>`)
 		EscapeHTML(w, node.Literal)

--- a/parser/block.go
+++ b/parser/block.go
@@ -1144,7 +1144,6 @@ func (p *Parser) tableHeader(data []byte) (size int, columns []ast.CellAlignFlag
 
 	table = &ast.Table{}
 	p.addBlock(table)
-	p.addBlock(&ast.TableHead{})
 	p.addBlock(&ast.TableHeader{})
 	p.tableRow(header, columns, true)
 	size = skipCharN(data, i, '\n', 1)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -207,12 +207,12 @@ func canNodeContain(n ast.Node, v ast.Node) bool {
 		return !isListItem(v)
 	case *ast.Table:
 		switch v.(type) {
-		case *ast.TableHead, *ast.TableBody:
+		case *ast.TableHeader, *ast.TableBody, *ast.TableFooter:
 			return true
 		default:
 			return false
 		}
-	case *ast.TableHead, *ast.TableBody:
+	case *ast.TableHeader, *ast.TableBody, *ast.TableFooter:
 		_, ok := v.(*ast.TableRow)
 		return ok
 	case *ast.TableRow:


### PR DESCRIPTION
This takes the syntax from kramdown: https://kramdown.gettalong.org/syntax.html#tables

It's not guarded by any parser extension, except the parser.Tables

Signed-off-by: Miek Gieben <miek@miek.nl>