### PR TITLE
Drop "Caption: " in favor of specific caption triggers

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -927,7 +927,7 @@ func (p *Parser) fencedCodeBlock(data []byte, doRender bool) int {
 		}
 
 		// Check for caption and if found make it a figure.
-		if captionContent, consumed := p.caption(data[beg:]); consumed > 0 {
+		if captionContent, consumed := p.caption(data[beg:], []byte("Figure: ")); consumed > 0 {
 			figure := &ast.CaptionFigure{}
 			caption := &ast.Caption{}
 			p.Inline(caption, captionContent)
@@ -1242,7 +1242,7 @@ func (p *Parser) quote(data []byte) int {
 		return end
 	}
 
-	if captionContent, consumed := p.caption(data[end:]); consumed > 0 {
+	if captionContent, consumed := p.caption(data[end:], []byte("Quote: ")); consumed > 0 {
 		figure := &ast.CaptionFigure{}
 		caption := &ast.Caption{}
 		p.Inline(caption, captionContent)

--- a/parser/caption.go
+++ b/parser/caption.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 )
 
-func (p *Parser) caption(data []byte) ([]byte, int) {
-	if !bytes.HasPrefix(data, []byte("Caption: ")) {
+func (p *Parser) caption(data, caption []byte) ([]byte, int) {
+	if !bytes.HasPrefix(data, caption) {
 		return nil, 0
 	}
-	j := len("Caption: ")
+	j := len(caption)
 	data = data[j:]
 	end := p.linesUntilEmpty(data)
 

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -21,7 +21,7 @@
 ~~~ go
 println("hi")
 ~~~
-Caption: This *is* a
+Figure: This *is* a
   caption.
 +++
 <h1>Test Code Captions</h1>
@@ -35,7 +35,7 @@ Caption: This *is* a
 # Test Quote Captions
 > To be, or not to be
 
-Caption: Shakespeare.
+Quote: Shakespeare.
 +++
 <h1>Test Quote Captions</h1>
 <figure>


### PR DESCRIPTION
This syntax was actually stolen from Pandoc, where it is used for
Tables (will update that, once those PRs are in). So leave the original
(from mmark1) syntax makes sense.

Signed-off-by: Miek Gieben <miek@miek.nl>