### PR TITLE
Fix special section

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -380,20 +380,20 @@ func TestPrefixHeaderMmarkExtension(t *testing.T) {
 	t.Parallel()
 	var tests = []string{
 		".# Header 1\n",
-		`<h1 special="header 1">Header 1</h1>` + "\n",
+		`<h1 class="special">Header 1</h1>` + "\n",
 
 		".## Header 2\n",
 		"<p>.## Header 2</p>\n",
 
 		"Hello\n.# Header 1\nGoodbye\n",
-		"<p>Hello</p>\n\n<h1 special=\"header 1\">Header 1</h1>\n\n<p>Goodbye</p>\n",
+		"<p>Hello</p>\n\n<h1 class=\"special\">Header 1</h1>\n\n<p>Goodbye</p>\n",
 
 		"* List\n.# Header\n* List\n",
-		"<ul>\n<li><p>List</p>\n\n<h1 special=\"header\">Header</h1></li>\n\n<li><p>List</p></li>\n</ul>\n",
+		"<ul>\n<li><p>List</p>\n\n<h1 class=\"special\">Header</h1></li>\n\n<li><p>List</p></li>\n</ul>\n",
 
 		"*   List\n    * Nested list\n    .# Nested header\n",
 		"<ul>\n<li><p>List</p>\n\n<ul>\n<li><p>Nested list</p>\n\n" +
-			"<h1 special=\"nested header\">Nested header</h1></li>\n</ul></li>\n</ul>\n",
+			"<h1 class=\"special\">Nested header</h1></li>\n</ul></li>\n</ul>\n",
 	}
 	doTestsBlock(t, tests, parser.Mmark)
 }

--- a/parser/block.go
+++ b/parser/block.go
@@ -933,6 +933,7 @@ func (p *Parser) fencedCodeBlock(data []byte, doRender bool) int {
 			p.Inline(caption, captionContent)
 
 			p.addBlock(figure)
+			codeBlock.AsLeaf().Attribute = figure.AsContainer().Attribute
 			p.addChild(codeBlock)
 			finalizeCodeBlock(codeBlock)
 			p.addChild(caption)
@@ -1011,6 +1012,8 @@ func (p *Parser) table(data []byte) int {
 		// Some switcheroo to re-insert the parsed table as a child of the captionfigure.
 		figure := &ast.CaptionFigure{}
 		table2 := &ast.Table{}
+		// Retain any block level attributes.
+		table2.AsContainer().Attribute = table.AsContainer().Attribute
 		children := table.GetChildren()
 		ast.RemoveFromTree(table)
 
@@ -1265,8 +1268,9 @@ func (p *Parser) quote(data []byte) int {
 		caption := &ast.Caption{}
 		p.Inline(caption, captionContent)
 
-		p.addBlock(figure)
+		p.addBlock(figure) // this discard any attributes
 		block := &ast.BlockQuote{}
+		block.AsContainer().Attribute = figure.AsContainer().Attribute
 		p.addChild(block)
 		p.block(raw.Bytes())
 		p.finalize(block)

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -4,7 +4,7 @@
 +++
 .# Test 2
 +++
-<h1 special="test 2">Test 2</h1>
+<h1 class="special">Test 2</h1>
 +++
 # Test 3
 {frontmatter}
@@ -136,3 +136,79 @@ A> This is an aside
 <aside>
 <p>This is an aside</p>
 </aside>
++++
+{.myclass3}
+.# Preface section
++++
+<h1 class="special" class="myclass3">Preface section</h1>
++++
+{.myclass4}
+A> hello
++++
+<aside class="myclass4">
+<p>hello</p>
+</aside>
++++
+{.thick}
+********
++++
+<hr class="thick">
++++
+{.myclass2}
+Name    | Age
+--------|------
+Bob     | 27
++++
+<table class="myclass2">
+<thead>
+<tr>
+<th>Name</th>
+<th>Age</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>Bob</td>
+<td>27</td>
+</tr>
+</tbody>
+</table>
++++
+{.myclass3}
+Just some text
++++
+<p class="myclass3">Just some text</p>
++++
+{type="roman"}
+1. List item1
+2. List item2
++++
+<ol type="roman">
+<li>List item1</li>
+<li>List item2</li>
+</ol>
++++
+{.myclass3}
+> Hallo
+
+Quote: Someone
++++
+<figure>
+<blockquote class="myclass3">
+<p>Hallo</p>
+</blockquote>
+<figcaption>Someone</figcaption>
+</figure>
++++
+{.myclass5}
+~~~
+println("Yep!")
+~~~
+Figure: Go code
++++
+<figure>
+<pre><code class="myclass5">println(&quot;Yep!&quot;)
+</code></pre>
+<figcaption>Go code</figcaption>
+</figure>


### PR DESCRIPTION
You can't make up you're own attributes, give special header the class
"special". Adjust all testcases.

`<hr>`: support block level attributes.

Add more tests for block level attributes.

Fix figure attributes, by re-adding the attribute to the inner block
(table, quote or code block).

Fixes #7

Signed-off-by: Miek Gieben <miek@miek.nl>