### PR TITLE
Update readme and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ implements the following extensions:
     Alice   | 23
     ```
 
+    Table footers are supported as well and can be added with equal signs (`=`):
+
+    ```
+    Name    | Age
+    --------|------
+    Bob     | 27
+    Alice   | 23
+    ========|======
+    Total   | 50
+    ```
+
 *   **Fenced code blocks**. In addition to the normal 4-space
     indentation to mark code blocks, you can explicitly mark them
     and supply a language (to make syntax highlighting simple). Just
@@ -276,12 +287,7 @@ implements the following extensions:
     ```
     Will convert into `<h1 id="id3" class="myclass" fontsize="tiny">Header 1</h1>`.
 
-*   **Mmark special heading**. A heading stating with `#.`, this makes it a special header. This can
-    be used to typeset Abstract or Prefaces.
-
-*   **Mmark document divisions**, allow front-, main- or backmatter.
-
-*   **Mmark captions**, allow captions under code blocks and block quotes, by using `Caption: <text>`
+*   **Mmark support**, see <https://mmark.nl/syntax> for all new syntax elements this adds.
 
 ## Todo
 

--- a/ast/node.go
+++ b/ast/node.go
@@ -223,7 +223,7 @@ type Heading struct {
 	Level        int    // This holds the heading level number
 	HeadingID    string // This might hold heading ID, if present
 	IsTitleblock bool   // Specifies whether it's a title block
-	Special      []byte // We are a special heading (start with .#), contains header name
+	IsSpecial    bool   // We are a special heading (starts with .#)
 }
 
 // HorizontalRule represents markdown horizontal rule node

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -592,11 +592,20 @@ func (r *Renderer) htmlBlock(w io.Writer, node *ast.HTMLBlock) {
 
 func (r *Renderer) headingEnter(w io.Writer, nodeData *ast.Heading) {
 	var attrs []string
+	var class string
+	// TODO(miek): add helper functions for coalescing these classes.
 	if nodeData.IsTitleblock {
-		attrs = append(attrs, `class="title"`)
+		class = "title"
 	}
-	if nodeData.Special != nil {
-		attrs = append(attrs, `class="special"`)
+	if nodeData.IsSpecial {
+		if class != "" {
+			class += " special"
+		} else {
+			class = "special"
+		}
+	}
+	if class != "" {
+		attrs = []string{`class="` + class + `"`}
 	}
 	if nodeData.HeadingID != "" {
 		id := r.ensureUniqueHeadingID(nodeData.HeadingID)

--- a/parser/block.go
+++ b/parser/block.go
@@ -477,6 +477,7 @@ func (p *Parser) prefixSpecialHeading(data []byte) int {
 			IsSpecial: true,
 			Level:     1, // always level 1.
 		}
+		block.Literal = data[i:end]
 		block.Content = data[i:end]
 		p.addBlock(block)
 	}

--- a/parser/block.go
+++ b/parser/block.go
@@ -474,7 +474,7 @@ func (p *Parser) prefixSpecialHeading(data []byte) int {
 		}
 		block := &ast.Heading{
 			HeadingID: id,
-			Special:   bytes.ToLower(data[i:end]),
+			IsSpecial: true,
 			Level:     1, // always level 1.
 		}
 		block.Content = data[i:end]


### PR DESCRIPTION
Update the README with table footer syntax: fixes #77
Update the README and just point to mmark.nl instead of listing
all mmark syntax elements (again).
Fix multiple classes in headers.
Make header.Special a bool and rename it it IsSpecial. fixes #75 

Signed-off-by: Miek Gieben <miek@miek.nl>