### PR TITLE
Table caption: add p.finalize

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -1028,6 +1028,8 @@ func (p *Parser) table(data []byte) int {
 		ast.AppendChild(figure, caption)
 
 		p.addChild(figure)
+		p.finalize(figure)
+
 		i += consumed
 	}
 


### PR DESCRIPTION
The block wasn't finalized leading to new content being add here.
Caught in mmark testing (and test case added).

Signed-off-by: Miek Gieben <miek@miek.nl>