### PR TITLE
Add super and subscript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ implements the following extensions:
 *   **Ordered list start number**. With this extension enabled an ordered list will start with the
     the number that was used to start it.
 
+*   **Super and subscript**. With this extension enabled sequences between ^ will indicate
+    superscript and ~ will become a subscript. For example: H~2~O is a liquid, 2^10^ is 1024.
+
 *   **Block level attributes**, allow setting attributes (ID, classes and key/value pairs) on block
     level elements. The attribute must be enclosed with braces and be put on a line before the
     element.

--- a/ast/node.go
+++ b/ast/node.go
@@ -381,6 +381,16 @@ type Index struct {
 	ID      string // ID of the index
 }
 
+// Subscript is a subscript node
+type Subscript struct {
+	Leaf
+}
+
+// Subscript is a superscript node
+type Superscript struct {
+	Leaf
+}
+
 func removeNodeFromArray(a []Node, node Node) []Node {
 	n := len(a)
 	for i := 0; i < n; i++ {

--- a/html/esc.go
+++ b/html/esc.go
@@ -34,3 +34,17 @@ func escLink(w io.Writer, text []byte) {
 	unesc := html.UnescapeString(string(text))
 	EscapeHTML(w, []byte(unesc))
 }
+
+// Escape writes the text to w, but skips the escape character.
+func Escape(w io.Writer, text []byte) {
+	esc := false
+	for i := 0; i < len(text); i++ {
+		if text[i] == '\\' {
+			esc = !esc
+		}
+		if esc && text[i] == '\\' {
+			continue
+		}
+		w.Write([]byte{text[i]})
+	}
+}

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -978,6 +978,18 @@ func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.Wal
 		r.callout(w, node)
 	case *ast.Index:
 		r.index(w, node)
+	case *ast.Subscript:
+		r.outOneOf(w, true, "<sub>", "</sub>")
+		if entering {
+			Escape(w, node.Literal)
+		}
+		r.outOneOf(w, false, "<sub>", "</sub>")
+	case *ast.Superscript:
+		r.outOneOf(w, true, "<sup>", "</sup>")
+		if entering {
+			Escape(w, node.Literal)
+		}
+		r.outOneOf(w, false, "<sup>", "</sup>")
 	default:
 		panic(fmt.Sprintf("Unknown node %T", node))
 	}

--- a/parser/esc.go
+++ b/parser/esc.go
@@ -1,0 +1,20 @@
+package parser
+
+// isEscape returns true if byte i is prefixed by an odd number of backslahses.
+func isEscape(data []byte, i int) bool {
+	if i == 0 {
+		return false
+	}
+	if i == 1 {
+		return data[0] == '\\'
+	}
+	j := i - 1
+	for ; j >= 0; j-- {
+		if data[j] != '\\' {
+			break
+		}
+	}
+	j++
+	// odd number of backslahes means escape
+	return (i-j)%2 != 0
+}

--- a/parser/esc_test.go
+++ b/parser/esc_test.go
@@ -1,0 +1,22 @@
+package parser
+
+import "testing"
+
+func TestIsEscape(t *testing.T) {
+	if x := `\a`; !isEscape([]byte(x), 1) {
+		t.Errorf("expected escape for %q, got false", x)
+	}
+	if x := `\\\a`; !isEscape([]byte(x), 3) {
+		t.Errorf("expected escape for %q, got false", x)
+	}
+	if x := `b\\\a`; !isEscape([]byte(x), 4) {
+		t.Errorf("expected escape for %q, got false", x)
+	}
+
+	if x := `\\a`; isEscape([]byte(x), 2) {
+		t.Errorf("expected no escape for %q, got true", x)
+	}
+	if x := `\\\\a`; isEscape([]byte(x), 4) {
+		t.Errorf("expected no escape for %q, got true", x)
+	}
+}

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -228,7 +228,7 @@ func maybeInlineFootnoteOrSuper(p *Parser, data []byte, offset int) (int, ast.No
 		}
 		sup := &ast.Superscript{}
 		sup.Literal = data[offset+1 : offset+ret]
-		return offset + ret + 1, sup
+		return offset + ret, sup
 	}
 
 	return 0, nil

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -68,8 +68,25 @@ func emphasis(p *Parser, data []byte, offset int) (int, ast.Node) {
 	if n > 2 && data[1] != c {
 		// whitespace cannot follow an opening emphasis;
 		// strikethrough only takes two characters '~~'
-		if c == '~' || isSpace(data[1]) {
+		if isSpace(data[1]) {
 			return 0, nil
+		}
+		if p.extensions&SuperSubScript != 0 && c == '~' {
+			// potential subscript, no spaces, except when escaped, helperEmphasis does
+			// not check that for us, so walk the bytes and check.
+			ret := skipUntilChar(data[1:], 0, c)
+			if ret == 0 {
+				return 0, nil
+			}
+			ret++ // we started with data[1:] above.
+			for i := 1; i < ret+1; i++ {
+				if isSpace(data[i]) && !isEscape(data, i) {
+					return 0, nil
+				}
+			}
+			sub := &ast.Subscript{}
+			sub.Literal = data[1:ret]
+			return ret + 1, sub
 		}
 		ret, node := helperEmphasis(p, data[1:], c)
 		if ret == 0 {
@@ -194,10 +211,26 @@ func maybeImage(p *Parser, data []byte, offset int) (int, ast.Node) {
 	return 0, nil
 }
 
-func maybeInlineFootnote(p *Parser, data []byte, offset int) (int, ast.Node) {
+func maybeInlineFootnoteOrSuper(p *Parser, data []byte, offset int) (int, ast.Node) {
 	if offset < len(data)-1 && data[offset+1] == '[' {
 		return link(p, data, offset)
 	}
+
+	if p.extensions&SuperSubScript != 0 {
+		ret := skipUntilChar(data[offset:], 1, '^')
+		if ret == 0 {
+			return 0, nil
+		}
+		for i := offset; i < offset+ret+1; i++ {
+			if isSpace(data[i]) && !isEscape(data, i) {
+				return 0, nil
+			}
+		}
+		sup := &ast.Superscript{}
+		sup.Literal = data[offset+1 : offset+ret]
+		return offset + ret + 1, sup
+	}
+
 	return 0, nil
 }
 

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -71,7 +71,7 @@ func emphasis(p *Parser, data []byte, offset int) (int, ast.Node) {
 		if isSpace(data[1]) {
 			return 0, nil
 		}
-		if p.extensions&SuperSubScript != 0 && c == '~' {
+		if p.extensions&SuperSubscript != 0 && c == '~' {
 			// potential subscript, no spaces, except when escaped, helperEmphasis does
 			// not check that for us, so walk the bytes and check.
 			ret := skipUntilChar(data[1:], 0, c)
@@ -216,7 +216,7 @@ func maybeInlineFootnoteOrSuper(p *Parser, data []byte, offset int) (int, ast.No
 		return link(p, data, offset)
 	}
 
-	if p.extensions&SuperSubScript != 0 {
+	if p.extensions&SuperSubscript != 0 {
 		ret := skipUntilChar(data[offset:], 1, '^')
 		if ret == 0 {
 			return 0, nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,6 +38,7 @@ const (
 	MathJax                                       // Parse MathJax
 	OrderedListStart                              // Keep track of the first number used when starting an ordered list.
 	Attributes                                    // Block Attributes
+	SuperSubScript                                // Super- and subscript support: 2^10^, H~2~O.
 	Mmark                                         // Support Mmark syntax, see https://mmark.nl/syntax
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
@@ -150,7 +151,7 @@ func NewWithExtensions(extension Extensions) *Parser {
 	if p.extensions&Mmark != 0 {
 		p.inlineCallback['('] = maybeShortRefOrIndex
 	}
-	p.inlineCallback['^'] = maybeInlineFootnote
+	p.inlineCallback['^'] = maybeInlineFootnoteOrSuper
 	if p.extensions&Autolink != 0 {
 		p.inlineCallback['h'] = maybeAutoLink
 		p.inlineCallback['m'] = maybeAutoLink

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,7 +38,7 @@ const (
 	MathJax                                       // Parse MathJax
 	OrderedListStart                              // Keep track of the first number used when starting an ordered list.
 	Attributes                                    // Block Attributes
-	SuperSubScript                                // Super- and subscript support: 2^10^, H~2~O.
+	SuperSubscript                                // Super- and subscript support: 2^10^, H~2~O.
 	Mmark                                         // Support Mmark syntax, see https://mmark.nl/syntax
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |


### PR DESCRIPTION
Other markdown parser put this behind an extension; do the same here:
extension: SuperSubscript.

Detect sequences between ^ and ~ as super and subscript respectively.

Signed-off-by: Miek Gieben <miek@miek.nl>