### PR TITLE
super-subscript: fix index out of range

### DIFF
--- a/mmark_test.go
+++ b/mmark_test.go
@@ -22,7 +22,7 @@ func TestMmark(t *testing.T) {
 		t.Fatalf("odd test tuples: %d", len(testdata))
 	}
 
-	ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart | parser.Mmark
+	ext := parser.CommonExtensions | parser.Attributes | parser.OrderedListStart | parser.SuperSubscript | parser.Mmark
 	for i := 0; i < len(testdata); i += 2 {
 		p := parser.NewWithExtensions(ext)
 

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -79,7 +79,7 @@ func emphasis(p *Parser, data []byte, offset int) (int, ast.Node) {
 				return 0, nil
 			}
 			ret++ // we started with data[1:] above.
-			for i := 1; i < ret+1; i++ {
+			for i := 1; i < ret; i++ {
 				if isSpace(data[i]) && !isEscape(data, i) {
 					return 0, nil
 				}
@@ -221,7 +221,7 @@ func maybeInlineFootnoteOrSuper(p *Parser, data []byte, offset int) (int, ast.No
 		if ret == 0 {
 			return 0, nil
 		}
-		for i := offset; i < offset+ret+1; i++ {
+		for i := offset; i < offset+ret; i++ {
 			if isSpace(data[i]) && !isEscape(data, i) {
 				return 0, nil
 			}

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -212,3 +212,11 @@ Figure: Go code
 </code></pre>
 <figcaption>Go code</figcaption>
 </figure>
++++
+water is H~2~O
++++
+<p>water is H<sub>2</sub>O</p>
++++
+1024 is 2^10^
++++
+<p>1024 is 2<sup>10</sup></p>


### PR DESCRIPTION
The +1 lead to out of bounds on the data slice.

Add test in testdata/mmark.test as well.

Signed-off-by: Miek Gieben <miek@miek.nl>