### PR TITLE
Allow hooking into footnote generation

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -391,6 +391,11 @@ type Superscript struct {
 	Leaf
 }
 
+// Footnotes is a node that contains all footnotes
+type Footnotes struct {
+	Container
+}
+
 func removeNodeFromArray(a []Node, node Node) []Node {
 	n := len(a)
 	for i := 0; i < n; i++ {

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -32,6 +32,7 @@ const (
 	CompletePage                              // Generate a complete HTML page
 	UseXHTML                                  // Generate XHTML output instead of HTML
 	FootnoteReturnLinks                       // Generate a link at the end of a footnote to return to the source
+	FootnoteNoHRTag                           // Do not output an HR after starting a footnote list.
 	Smartypants                               // Enable smart punctuation substitutions
 	SmartypantsFractions                      // Enable smart fractions (with Smartypants)
 	SmartypantsDashes                         // Enable smart dashes (with Smartypants)
@@ -654,8 +655,10 @@ func (r *Renderer) listEnter(w io.Writer, nodeData *ast.List) {
 
 	if nodeData.IsFootnotesList {
 		r.outs(w, "\n<div class=\"footnotes\">\n\n")
-		r.outHRTag(w, nil)
-		r.cr(w)
+		if r.opts.Flags&FootnoteNoHRTag == 0 {
+			r.outHRTag(w, nil)
+			r.cr(w)
+		}
 	}
 	r.cr(w)
 	if isListItem(nodeData.Parent) {
@@ -990,6 +993,8 @@ func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.Wal
 			Escape(w, node.Literal)
 		}
 		r.outOneOf(w, false, "<sup>", "</sup>")
+	case *ast.Footnotes:
+		// nothing by default; just output the list.
 	default:
 		panic(fmt.Sprintf("Unknown node %T", node))
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -288,6 +288,7 @@ func (p *Parser) parseRefsToAST() {
 		IsFootnotesList: true,
 		ListFlags:       ast.ListTypeOrdered,
 	}
+	p.addBlock(&ast.Footnotes{})
 	block := p.addBlock(list)
 	flags := ast.ListItemBeginningOfList
 	// Note: this loop is intentionally explicit, not range-form. This is


### PR DESCRIPTION
This adds an (empty) *ast.Footnote before the footnotes are added.
This can be used to customize the it, i.e. putting it in a new section.
The HR output is put behind a flag html.FootnoteNoHRTag to suppress that
as well.

Fixes #80

Signed-off-by: Miek Gieben <miek@miek.nl>