### PR TITLE
Aside check uses 'or' should be 'and'

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -249,7 +249,7 @@ func (p *Parser) block(data []byte) {
 		//
 		// A> The proof is too large to fit
 		// A> in the margin.
-		if p.extensions|Mmark != 0 {
+		if p.extensions&Mmark != 0 {
 			if p.asidePrefix(data) > 0 {
 				data = data[p.aside(data):]
 				continue


### PR DESCRIPTION
One char fix: | --> &

Check was wrong, but happen to work.

Signed-off-by: Miek Gieben <miek@miek.nl>