### PR TITLE
parser: Implement Subfigures

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -256,6 +256,19 @@ func (p *Parser) block(data []byte) {
 			}
 		}
 
+		// figure block:
+		//
+		// !---
+		// ![Alt Text](img.jpg "This is an image")
+		// ![Alt Text](img2.jpg "This is a second image")
+		// !---
+		if p.extensions&Mmark != 0 {
+			if i := p.figureBlock(data, true); i > 0 {
+				data = data[i:]
+				continue
+			}
+		}
+
 		// table:
 		//
 		// Name  | Age | Phone
@@ -1854,6 +1867,14 @@ func (p *Parser) paragraph(data []byte) int {
 		// if there's a fenced code block, paragraph is over
 		if p.extensions&FencedCode != 0 {
 			if p.fencedCodeBlock(current, false) > 0 {
+				p.renderParagraph(data[:i])
+				return i
+			}
+		}
+
+		// if there's a figure block, paragraph is over
+		if p.extensions&Mmark != 0 {
+			if p.figureBlock(current, false) > 0 {
 				p.renderParagraph(data[:i])
 				return i
 			}

--- a/parser/figures.go
+++ b/parser/figures.go
@@ -1,0 +1,116 @@
+package parser
+
+import (
+	"bytes"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+// sFigureLine checks if there's a figure line (e.g., !--- ) at the beginning of data,
+// and returns the end index if so, or 0 otherwise.
+func sFigureLine(data []byte, oldmarker string) (end int, marker string) {
+	i, size := 0, 0
+
+	n := len(data)
+	// skip up to three spaces
+	for i < n && i < 3 && data[i] == ' ' {
+		i++
+	}
+
+	// check for the marker characters: !
+	if i+1 >= n {
+		return 0, ""
+	}
+	if data[i] != '!' || data[i+1] != '-' {
+		return 0, ""
+	}
+	i++
+
+	c := data[i] // i.e. the -
+
+	// the whole line must be the same char or whitespace
+	for i < n && data[i] == c {
+		size++
+		i++
+	}
+
+	// the marker char must occur at least 3 times
+	if size < 3 {
+		return 0, ""
+	}
+	marker = string(data[i-size : i])
+
+	// if this is the end marker, it must match the beginning marker
+	if oldmarker != "" && marker != oldmarker {
+		return 0, ""
+	}
+
+	// there is no syntax modifier although it might be an idea to re-use this space for something?
+
+	i = skipChar(data, i, ' ')
+	if i >= n || data[i] != '\n' {
+		if i == n {
+			return i, marker
+		}
+		return 0, ""
+	}
+	return i + 1, marker // Take newline into account.
+}
+
+// figureBlock returns the end index if data contains a figure block at the beginning,
+// or 0 otherwise. It writes to out if doRender is true, otherwise it has no side effects.
+// If doRender is true, a final newline is mandatory to recognize the figure block.
+func (p *Parser) figureBlock(data []byte, doRender bool) int {
+	beg, marker := sFigureLine(data, "")
+	if beg == 0 || beg >= len(data) {
+		return 0
+	}
+
+	var raw bytes.Buffer
+
+	for {
+		// safe to assume beg < len(data)
+
+		// check for the end of the code block
+		figEnd, _ := sFigureLine(data[beg:], marker)
+		if figEnd != 0 {
+			beg += figEnd
+			break
+		}
+
+		// copy the current line
+		end := skipUntilChar(data, beg, '\n') + 1
+
+		// did we reach the end of the buffer without a closing marker?
+		if end >= len(data) {
+			return 0
+		}
+
+		// verbatim copy to the working buffer
+		if doRender {
+			raw.Write(data[beg:end])
+		}
+		beg = end
+	}
+
+	if !doRender {
+		return beg
+	}
+
+	figure := &ast.CaptionFigure{}
+	p.addBlock(figure)
+	p.block(raw.Bytes())
+
+	defer p.finalize(figure)
+
+	if captionContent, consumed := p.caption(data[beg:], []byte("Figure: ")); consumed > 0 {
+		caption := &ast.Caption{}
+		p.Inline(caption, captionContent)
+		p.addChild(caption)
+
+		beg += consumed
+	}
+
+	p.finalize(figure)
+	return beg
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -204,7 +204,7 @@ func canNodeContain(n ast.Node, v ast.Node) bool {
 	switch n.(type) {
 	case *ast.List:
 		return isListItem(v)
-	case *ast.Document, *ast.BlockQuote, *ast.Aside, *ast.ListItem:
+	case *ast.Document, *ast.BlockQuote, *ast.Aside, *ast.ListItem, *ast.CaptionFigure:
 		return !isListItem(v)
 	case *ast.Table:
 		switch v.(type) {
@@ -219,13 +219,6 @@ func canNodeContain(n ast.Node, v ast.Node) bool {
 	case *ast.TableRow:
 		_, ok := v.(*ast.TableCell)
 		return ok
-	case *ast.CaptionFigure:
-		switch v.(type) {
-		case *ast.CodeBlock, *ast.BlockQuote, *ast.Caption:
-			return true
-		default:
-			return false
-		}
 	}
 	return false
 }

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -220,3 +220,14 @@ water is H~2~O
 1024 is 2^10^
 +++
 <p>1024 is 2<sup>10</sup></p>
++++
+!---
+![Alt text](/path/to/img1.jpg "Optional title")
+![Alt text](/path/to/img2.jpg "Optional title")
+!---
+Figure: this is a figure containing subfigures.
++++
+<figure><p><img src="/path/to/img1.jpg" alt="Alt text" title="Optional title" />
+<img src="/path/to/img2.jpg" alt="Alt text" title="Optional title" /></p>
+<figcaption>this is a figure containing subfigures.</figcaption>
+</figure>


### PR DESCRIPTION
This adds new block syntax that allows you to put multiple figures (or
other block elements) in a larger figure; essentially having subfigures.
Is only enabled when the Mmark extension is on.

The trigger is `!---` as it looks like a code block. This also allows
you to set block level attributes on the element.

See https://mmark.nl/post/syntax/#figures-and-subfigures for some extra
wording on the new syntax.

Signed-off-by: Miek Gieben <miek@miek.nl>