### PR TITLE
port https://github.com/russross/blackfriday/issues/239

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -1513,6 +1513,44 @@ func TestMathBlock(t *testing.T) {
 	doTestsBlock(t, tests, parser.CommonExtensions)
 }
 
+func TestListWithFencedCodeBlock(t *testing.T) {
+	var tests = []string{
+		"1. one\n\n    ```\n    code\n    ```\n\n2. two\n",
+		"<ol>\n<li><p>one</p>\n\n<pre><code>code\n</code></pre></li>\n\n<li><p>two</p></li>\n</ol>\n",
+		// https://github.com/russross/blackfriday/issues/239
+		"1. one\n\n    ```\n    - code\n    ```\n\n2. two\n",
+		"<ol>\n<li><p>one</p>\n\n<pre><code>- code\n</code></pre></li>\n\n<li><p>two</p></li>\n</ol>\n",
+	}
+	doTestsBlock(t, tests, parser.FencedCode)
+}
+
+func TestListWithMalformedFencedCodeBlock(t *testing.T) {
+	// Ensure that in the case of an unclosed fenced code block in a list,
+	// no source gets ommitted (even if it is malformed).
+	// See russross/blackfriday#372 for context.
+	var tests = []string{
+		"1. one\n\n    ```\n    code\n\n2. two\n",
+		"<ol>\n<li>one\n```\ncode\n2. two</li>\n</ol>\n",
+
+		"1. one\n\n    ```\n    - code\n\n2. two\n",
+		"<ol>\n<li>one\n```\n- code\n2. two</li>\n</ol>\n",
+	}
+	doTestsBlock(t, tests, parser.FencedCode)
+}
+
+func TestListWithFencedCodeBlockNoExtensions(t *testing.T) {
+	// If there is a fenced code block in a list, and FencedCode is not set,
+	// lists should be processed normally.
+	var tests = []string{
+		"1. one\n\n    ```\n    code\n    ```\n\n2. two\n",
+		"<ol>\n<li><p>one</p>\n\n<p><code>\ncode\n</code></p></li>\n\n<li><p>two</p></li>\n</ol>\n",
+
+		"1. one\n\n    ```\n    - code\n    ```\n\n2. two\n",
+		"<ol>\n<li><p>one</p>\n\n<p>```</p>\n\n<ul>\n<li>code\n```</li>\n</ul></li>\n\n<li><p>two</p></li>\n</ol>\n",
+	}
+	doTestsBlock(t, tests, 0)
+}
+
 func TestTitleBlock_EXTENSION_TITLEBLOCK(t *testing.T) {
 	t.Parallel()
 	var tests = []string{

--- a/parser/block.go
+++ b/parser/block.go
@@ -1571,6 +1571,7 @@ func (p *Parser) listItem(data []byte, flags *ast.ListType) int {
 	// process the following lines
 	containsBlankLine := false
 	sublist := 0
+	codeBlockMarker := ""
 
 gatherlines:
 	for line < len(data) {
@@ -1603,6 +1604,27 @@ gatherlines:
 		}
 
 		chunk := data[line+indentIndex : i]
+
+		if p.extensions&FencedCode != 0 {
+			// determine if in or out of codeblock
+			// if in codeblock, ignore normal list processing
+			_, marker := sFenceLine(chunk, nil, codeBlockMarker)
+			if marker != "" {
+				if codeBlockMarker == "" {
+					// start of codeblock
+					codeBlockMarker = marker
+				} else {
+					// end of codeblock.
+					codeBlockMarker = ""
+				}
+			}
+			// we are in a codeblock, write line, and continue
+			if codeBlockMarker != "" || marker != "" {
+				raw.Write(data[line+indentIndex : i])
+				line = i
+				continue gatherlines
+			}
+		}
 
 		// evaluate how this line fits in
 		switch {


### PR DESCRIPTION
This fixes the same issue, but in this code base. Patching was done
manual, but with minimal effort.

Signed-off-by: Miek Gieben <miek@miek.nl>

full details:

~~~
% wget https://patch-diff.githubusercontent.com/raw/russross/blackfriday/pull/372.patch
...
Saving to: ‘372.patch’
~~~

Edit `372.patch` to fix the path nams -> a/block.go -> a/parser/block.go etc.

~~~
% patch -p1 --dry-run < 372.patch
checking file block_test.go
Hunk #1 succeeded at 1513 with fuzz 2 (offset 55 lines).
checking file parser/block.go
Hunk #1 succeeded at 1571 (offset 325 lines).
Hunk #2 succeeded at 1605 (offset 325 lines).
checking file parser/block.go
Hunk #1 FAILED at 1293.
1 out of 1 hunk FAILED
checking file parser/block.go
Hunk #1 FAILED at 1280.
1 out of 1 hunk FAILED
checking file block_test.go
Hunk #1 succeeded at 1513 with fuzz 2 (offset 44 lines).
~~~

looks promising. Let's do this for real and manual fix.

~~~
% patch -p1 --merge < 372.patch
patching file block_test.go
Hunk #1 merged at 1516-1526.
patching file parser/block.go
patching file parser/block.go
patching file parser/block.go
patching file block_test.go
Hunk #1 merged at 1527-1553.
~~~