### PR TITLE
parser: fix def. list containing a codeblock

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -1538,6 +1538,14 @@ func TestListWithMalformedFencedCodeBlock(t *testing.T) {
 	doTestsBlock(t, tests, parser.FencedCode)
 }
 
+func TestDefinitionListWithFencedCodeBlock(t *testing.T) {
+	var tests = []string{
+		"one:\n: def1\n\ntwo:\n: def2\n\n ~~~\ncode\n ~~~\n",
+		"<dl>\n<dt>one:</dt>\n<dd><p>def1</p></dd>\n<dt>two:</dt>\n<dd><p>def2</p>\n\n<pre><code>code\n</code></pre></dd>\n</dl>\n",
+	}
+	doTestsBlock(t, tests, parser.FencedCode|parser.DefinitionLists)
+}
+
 func TestListWithFencedCodeBlockNoExtensions(t *testing.T) {
 	// If there is a fenced code block in a list, and FencedCode is not set,
 	// lists should be processed normally.

--- a/parser/block.go
+++ b/parser/block.go
@@ -1627,7 +1627,10 @@ gatherlines:
 					// start of codeblock
 					codeBlockMarker = marker
 				} else {
-					// end of codeblock.
+					// end of codeblock, mark list as containing a block
+					if containsBlankLine {
+						*flags |= ast.ListItemContainsBlock
+					}
 					codeBlockMarker = ""
 				}
 			}


### PR DESCRIPTION
See the detail in #102. This make a list containing a code block a list
containing a block. Add specific test case of a code block in a list.

Fixes #102

Signed-off-by: Miek Gieben <miek@miek.nl>