### PR TITLE
mmark citation: create option for rendering

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -84,8 +84,10 @@ type RendererOptions struct {
 	// FootnoteReturnLinks flag is enabled. If blank, the string
 	// <sup>[return]</sup> is used.
 	FootnoteReturnLinkContents string
-	// If set, add this text to the front of each Heading ID, to ensure
-	// uniqueness.
+	// CitationFormatString defines how a citation is rendered. If blnck, the string
+	// <sup>[%s]</sup> is used. Where %s will be substituted with the citation target.
+	CitationFormatString string
+	// If set, add this text to the front of each Heading ID, to ensure uniqueness.
 	HeadingIDPrefix string
 	// If set, add this text to the back of each Heading ID, to ensure uniqueness.
 	HeadingIDSuffix string
@@ -136,6 +138,9 @@ func NewRenderer(opts RendererOptions) *Renderer {
 
 	if opts.FootnoteReturnLinkContents == "" {
 		opts.FootnoteReturnLinkContents = `<sup>[return]</sup>`
+	}
+	if opts.CitationFormatString == "" {
+		opts.CitationFormatString = `<sup>[%s]</sup>`
 	}
 
 	return &Renderer{
@@ -870,7 +875,7 @@ func (r *Renderer) citation(w io.Writer, node *ast.Citation) {
 			attr[0] = `class="suppressed"`
 		}
 		r.outTag(w, "<cite", attr)
-		r.outs(w, fmt.Sprintf(`<a href="#`+"%s"+`"></a>`, c))
+		r.outs(w, fmt.Sprintf(`<a href="#%s">`+r.opts.CitationFormatString+`</a>`, c, c))
 		r.outs(w, "</cite>")
 	}
 }

--- a/testdata/mmark.test
+++ b/testdata/mmark.test
@@ -56,21 +56,21 @@ Quote: Shakespeare.
 +++
 <h1>Test Citations</h1>
 
-<p><cite class="informative"><a href="#RFC1034"></a></cite></p>
+<p><cite class="informative"><a href="#RFC1034"><sup>[RFC1034]</sup></a></cite></p>
 +++
 # Test Multiple Citations
 [@RFC1034; @!RFC1035]
 +++
 <h1>Test Multiple Citations</h1>
 
-<p><cite class="informative"><a href="#RFC1034"></a></cite><cite class="normative"><a href="#RFC1035"></a></cite></p>
+<p><cite class="informative"><a href="#RFC1034"><sup>[RFC1034]</sup></a></cite><cite class="normative"><a href="#RFC1035"><sup>[RFC1035]</sup></a></cite></p>
 +++
 # Test Multiple Citations with modifier
 [@-RFC1034] [@?RFC1035]
 +++
 <h1>Test Multiple Citations with modifier</h1>
 
-<p><cite class="suppressed"><a href="#RFC1034"></a></cite> <cite class="informative"><a href="#RFC1035"></a></cite></p>
+<p><cite class="suppressed"><a href="#RFC1034"><sup>[RFC1034]</sup></a></cite> <cite class="informative"><a href="#RFC1035"><sup>[RFC1035]</sup></a></cite></p>
 +++
 {.myclass1 .myclass2}
 ~~~


### PR DESCRIPTION
Render citations more sanely add `<sup>CITATION</sup>` as the default.
Also add the infra for this to be overruled.

Signed-off-by: Miek Gieben <miek@miek.nl>