### PR TITLE
Fix definition list in definition lists

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -887,6 +887,39 @@ func TestDefinitionList(t *testing.T) {
 	doTestsBlock(t, tests, parser.DefinitionLists)
 }
 
+func TestNestedDefinitionList(t *testing.T) {
+	t.Parallel()
+	var tests = []string{
+		// Definition list in def. list.
+		`Term 1
+:   Definition
+Next line
+
+Term 2
+:   Definition b
+
+    Term 11
+    :   Definition c
+`, "<dl>\n<dt>Term 1</dt>\n<dd><p>Definition\nNext line</p></dd>\n<dt>Term 2</dt>\n<dd><p>Definition b</p>\n\n<dl>\n<dt>Term 11</dt>\n<dd>Definition c</dd>\n</dl></dd>\n</dl>\n",
+
+		// Definition list in def. list with sublist.
+		`Term 1
+:   Definition
+Next line
+
+Term 2
+:   Definition b
+
+    Term 11
+    :   Definition c
+
+    * sublist1
+    * sublist2
+`, "<dl>\n<dt>Term 1</dt>\n<dd><p>Definition\nNext line</p></dd>\n<dt>Term 2</dt>\n<dd><p>Definition b</p>\n\n<dl>\n<dt>Term 11</dt>\n<dd>Definition c</dd>\n</dl>\n\n<ul>\n<li>sublist1</li>\n<li>sublist2</li>\n</ul></dd>\n</dl>\n",
+	}
+	doTestsBlock(t, tests, parser.DefinitionLists)
+}
+
 func TestPreformattedHtml(t *testing.T) {
 	t.Parallel()
 	var tests = []string{

--- a/parser/block.go
+++ b/parser/block.go
@@ -1620,9 +1620,7 @@ gatherlines:
 		// evaluate how this line fits in
 		switch {
 		// is this a nested list item?
-		case (p.uliPrefix(chunk) > 0 && !p.isHRule(chunk)) ||
-			p.oliPrefix(chunk) > 0 ||
-			p.dliPrefix(chunk) > 0:
+		case (p.uliPrefix(chunk) > 0 && !p.isHRule(chunk)) || p.oliPrefix(chunk) > 0 || p.dliPrefix(chunk) > 0:
 
 			// to be a nested list, it must be indented more
 			// if not, it is either a different kind of list
@@ -1644,6 +1642,11 @@ gatherlines:
 			// is this the first item in the nested list?
 			if sublist == 0 {
 				sublist = raw.Len()
+				// in the case of dliPrefix we are too late and need to search back for the definition item, which
+				// should be on the previous line, we then adjust sublist to start there.
+				if p.dliPrefix(chunk) > 0 {
+					sublist = backUntilChar(raw.Bytes(), raw.Len()-1, '\n')
+				}
 			}
 
 			// is this a nested prefix heading?
@@ -1958,6 +1961,13 @@ func skipSpace(data []byte, i int) int {
 
 func backChar(data []byte, i int, c byte) int {
 	for i > 0 && data[i-1] == c {
+		i--
+	}
+	return i
+}
+
+func backUntilChar(data []byte, i int, c byte) int {
+	for i > 0 && data[i-1] != c {
 		i--
 	}
 	return i


### PR DESCRIPTION
Because we are a line by line parser with are too late to detect nested
definition lists. The fix implemented here detects that we are in this
situation and then backtracks to search for the beginning of the
previous line and starts the sublist there.

This doesn't break any existing test. Added def-in-def tests for this
particular case.

Signed-off-by: Miek Gieben <miek@miek.nl>