### PR TITLE
Fix duplicate and recursive footnotes

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -927,6 +927,27 @@ what happens here
 [^footnote]: But it has a footnote! And it gets omitted.
 `,
 	"<p>This text does not reference a footnote.</p>\n",
+
+	`testing footnotes.[^a]
+ test footnotes the second.[^b]
+ [^a]: This is the first note[^a].
+[^b]: this is the second note.[^a]
+`,
+	`<p>testing footnotes.<sup class="footnote-ref" id="fnref:a"><a href="#fn:a">1</a></sup>
+ test footnotes the second.<sup class="footnote-ref" id="fnref:b"><a href="#fn:b">2</a></sup></p>
+
+<div class="footnotes">
+
+<hr />
+
+<ol>
+<li id="fn:a">This is the first note<sup class="footnote-ref" id="fnref:a"><a href="#fn:a">1</a></sup>.</li>
+
+<li id="fn:b">this is the second note.<sup class="footnote-ref" id="fnref:a"><a href="#fn:a">1</a></sup></li>
+</ol>
+
+</div>
+`,
 }
 
 func TestFootnotes(t *testing.T) {
@@ -983,6 +1004,36 @@ func TestNestedFootnotes(t *testing.T) {
 <li id="fn:fn1">Asterisk<sup class="footnote-ref" id="fnref:fn2"><a href="#fn:fn2">2</a></sup></li>
 
 <li id="fn:fn2">Obelisk</li>
+</ol>
+
+</div>
+`,
+		`This uses footnote A.[^A]
+
+This uses footnote C.[^C]
+
+[^A]:
+  A note. use itself.[^A]
+[^B]:
+  B note, uses A to test duplicate.[^A]
+[^C]:
+  C note, uses B.[^B]
+`,
+
+		`<p>This uses footnote A.<sup class="footnote-ref" id="fnref:A"><a href="#fn:A">1</a></sup></p>
+
+<p>This uses footnote C.<sup class="footnote-ref" id="fnref:C"><a href="#fn:C">2</a></sup></p>
+
+<div class="footnotes">
+
+<hr />
+
+<ol>
+<li id="fn:A">A note. use itself.<sup class="footnote-ref" id="fnref:A"><a href="#fn:A">1</a></sup></li>
+
+<li id="fn:C">C note, uses B.<sup class="footnote-ref" id="fnref:B"><a href="#fn:B">3</a></sup></li>
+
+<li id="fn:B">B note, uses A to test duplicate.<sup class="footnote-ref" id="fnref:A"><a href="#fn:A">1</a></sup></li>
 </ol>
 
 </div>

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -512,6 +512,7 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 			}
 
 			p.notes = append(p.notes, ref)
+			p.refsRecord[string(ref.link)] = struct{}{}
 
 			link = ref.link
 			title = ref.title
@@ -522,10 +523,11 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 				return 0, nil
 			}
 
-			if t == linkDeferredFootnote {
+			if t == linkDeferredFootnote && !p.isFootnote(lr) {
 				lr.noteID = len(p.notes) + 1
 				lr.footnote = footnoteNode
 				p.notes = append(p.notes, lr)
+				p.refsRecord[string(lr.link)] = struct{}{}
 			}
 
 			// keep link and title from reference

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -89,6 +89,7 @@ type Parser struct {
 	extensions Extensions
 
 	refs           map[string]*reference
+	refsRecord     map[string]struct{}
 	inlineCallback [256]inlineParser
 	nesting        int
 	maxNesting     int
@@ -124,6 +125,7 @@ func New() *Parser {
 func NewWithExtensions(extension Extensions) *Parser {
 	p := Parser{
 		refs:         make(map[string]*reference),
+		refsRecord:   make(map[string]struct{}),
 		maxNesting:   16,
 		insideLink:   false,
 		Doc:          &ast.Document{},
@@ -185,6 +187,11 @@ func (p *Parser) getRef(refid string) (ref *reference, found bool) {
 	// refs are case insensitive
 	ref, found = p.refs[strings.ToLower(refid)]
 	return ref, found
+}
+
+func (p *Parser) isFootnote(ref *reference) bool {
+	_, ok := p.refsRecord[string(ref.link)]
+	return ok
 }
 
 func (p *Parser) finalize(block ast.Node) {


### PR DESCRIPTION
Fix the infinite loop when there is a self-refer footnote by checking if
the reference is already added into parser.notes.

It also fixes of creating duplicate footnotes through this modification.

Add coresponding testcase.

Original PR: https://github.com/russross/blackfriday/pull/366
Fixes: https://github.com/mmarkdown/mmark/issues/25

Signed-off-by: Miek Gieben <miek@miek.nl>