### PR TITLE
Add Includes extension

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -106,7 +106,7 @@ func (p *Parser) block(data []byte) {
 			data = p.attribute(data)
 		}
 
-		if p.extensions&Mmark != 0 {
+		if p.extensions&Includes != 0 {
 			f := p.readInclude
 			path, address, consumed := p.isInclude(data)
 			if consumed == 0 {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -39,6 +39,7 @@ const (
 	OrderedListStart                              // Keep track of the first number used when starting an ordered list.
 	Attributes                                    // Block Attributes
 	SuperSubscript                                // Super- and subscript support: 2^10^, H~2~O.
+	Includes                                      // Support including other files.
 	Mmark                                         // Support Mmark syntax, see https://mmark.nl/syntax
 
 	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |


### PR DESCRIPTION
The ability to toggle Includes, regardless of Mmark can be imported:
make a separate extenions: "Includes"

I'm writing a renderer that outputs Markdown, it is impossible to hook
into the include code to say: "leave those alone for now", so having a
new Extension seems like the cleanest way of doing this.

Signed-off-by: Miek Gieben <miek@miek.nl>