### PR TITLE
mmark: allow citation suffix

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -269,6 +269,7 @@ type Citation struct {
 
 	Destination [][]byte        // Destination is where the citation points to. Multiple ones are allowed.
 	Type        []CitationTypes // 1:1 mapping of destination and citation type
+	Suffix      [][]byte        // Potential citation suffix, i.e. [@!RFC1035, p. 144]
 }
 
 // Image represents markdown image node

--- a/parser/citation.go
+++ b/parser/citation.go
@@ -7,12 +7,15 @@ import (
 )
 
 // citation parses a citation. In its most simple form [@ref], we allow multiple
-// being separated by semicolons and a sub reference inside ala pandoc: [@ref p. 23].
+// being separated by semicolons and a sub reference inside ala pandoc: [@ref, p. 23].
 // Each citation can have a modifier: !, ? or - wich mean:
 //
 // ! - normative
 // ? - formative
 // - - suppressed
+//
+// The suffix starts after a comma, we strip any whitespace before and after. If the output
+// allows for it, this can be rendered.
 func citation(p *Parser, data []byte, offset int) (int, ast.Node) {
 	// look for the matching closing bracket
 	i := offset + 1
@@ -44,11 +47,21 @@ func citation(p *Parser, data []byte, offset int) (int, ast.Node) {
 
 	citations := bytes.Split(data[1:i], []byte(";"))
 	for _, citation := range citations {
+		var suffix []byte
 		citation = bytes.TrimSpace(citation)
 		j := 0
 		if citation[j] != '@' {
 			// not a citation, drop out entirely.
 			return 0, nil
+		}
+		if c := bytes.Index(citation, []byte(",")); c > 0 {
+			part := citation[:c]
+			suff := citation[c+1:]
+			part = bytes.TrimSpace(part)
+			suff = bytes.TrimSpace(suff)
+
+			citation = part
+			suffix = suff
 		}
 
 		citeType := ast.CitationTypeInformative
@@ -66,6 +79,7 @@ func citation(p *Parser, data []byte, offset int) (int, ast.Node) {
 		}
 		node.Destination = append(node.Destination, citation[j:])
 		node.Type = append(node.Type, citeType)
+		node.Suffix = append(node.Suffix, suffix)
 	}
 
 	return i + 1, node

--- a/parser/citation_test.go
+++ b/parser/citation_test.go
@@ -1,0 +1,67 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+func TestCitation(t *testing.T) {
+	data := []byte(`[@!RFC1035]`)
+
+	p := New()
+	p.extensions |= Mmark
+
+	_, node := citation(p, data, 0)
+	dest := string(node.(*ast.Citation).Destination[0])
+	if dest != "RFC1035" {
+		t.Errorf("failed to find citation, want %s, got %s", "RFC1035", dest)
+	}
+	tp := node.(*ast.Citation).Type[0]
+	if tp != ast.CitationTypeNormative {
+		t.Errorf("failed to find citation type, want %d, got %d", ast.CitationTypeNormative, tp)
+	}
+}
+
+func TestCitationSuffix(t *testing.T) {
+	data := []byte(`[@!RFC1035, p. 144]`)
+
+	p := New()
+	p.extensions |= Mmark
+
+	_, node := citation(p, data, 0)
+	if dest := string(node.(*ast.Citation).Destination[0]); dest != "RFC1035" {
+		t.Errorf("failed to find citation, want %s, got %s", "RFC1035", dest)
+	}
+	tp := node.(*ast.Citation).Type[0]
+	if tp != ast.CitationTypeNormative {
+		t.Errorf("failed to find citation type, want %d, got %d", ast.CitationTypeNormative, tp)
+	}
+	suff := string(node.(*ast.Citation).Suffix[0])
+	if suff != "p. 144" {
+		t.Errorf("failed to find citation suffix, want %s, got %s", "p. 144", suff)
+	}
+}
+
+func TestCitationSuffixMultiple(t *testing.T) {
+	data := []byte(`[@?RFC1034; @!RFC1035, p. 144, more]`)
+
+	p := New()
+	p.extensions |= Mmark
+
+	_, node := citation(p, data, 0)
+	if dest := string(node.(*ast.Citation).Destination[0]); dest != "RFC1034" {
+		t.Errorf("failed to find citation, want %s, got %s", "RFC1034", dest)
+	}
+	tp := node.(*ast.Citation).Type[0]
+	if tp != ast.CitationTypeInformative {
+		t.Errorf("failed to find citation type, want %d, got %d", ast.CitationTypeInformative, tp)
+	}
+	if dest := string(node.(*ast.Citation).Destination[1]); dest != "RFC1035" {
+		t.Errorf("failed to find citation, want %s, got %s", "RFC1035", dest)
+	}
+	suff := string(node.(*ast.Citation).Suffix[1])
+	if suff != "p. 144, more" {
+		t.Errorf("failed to find citation suffix, want %s, got %s", "p. 144, more", suff)
+	}
+}


### PR DESCRIPTION
mmark 2 promised to implement this: allow a citation suffix:
[@!RFC1034, p. 144]. Implement this by splitting on the comma.
Add multiple tests for this new behavior.

Signed-off-by: Miek Gieben <miek@miek.nl>