### PR TITLE
links: keep deferred status

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -254,6 +254,7 @@ type Link struct {
 	Title       []byte // Title is the tooltip thing that goes in a title attribute
 	NoteID      int    // NoteID contains a serial number of a footnote, zero if it's not a footnote
 	Footnote    Node   // If it's a footnote, this is a direct link to the footnote Node. Otherwise nil.
+	DeferredID  []byte // If a deferred link this holds the original ID.
 }
 
 // CrossReference is a reference node.

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -275,10 +275,10 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 	}
 
 	var (
-		i                       = 1
-		noteID                  int
-		title, link, altContent []byte
-		textHasNl               = false
+		i                               = 1
+		noteID                          int
+		title, link, linkID, altContent []byte
+		textHasNl                       = false
 	)
 
 	if t == linkDeferredFootnote {
@@ -453,6 +453,7 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 		}
 
 		// keep link and title from reference
+		linkID = id
 		link = lr.link
 		title = lr.title
 		if altContentConsidered {
@@ -561,6 +562,7 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 		link := &ast.Link{
 			Destination: normalizeURI(uLink),
 			Title:       title,
+			DeferredID:  linkID,
 		}
 		if len(altContent) > 0 {
 			ast.AppendChild(link, newTextNode(altContent))
@@ -588,6 +590,9 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 			Title:       title,
 			NoteID:      noteID,
 			Footnote:    footnoteNode,
+		}
+		if t == linkDeferredFootnote {
+			link.DeferredID = data[2:txtE]
 		}
 		if t == linkInlineFootnote {
 			i++


### PR DESCRIPTION
Keep track if a link or footnote was deferred. This makes it possible to
do this again when generating (formatted) markdown output. I.e. now all
deferred links/footnotes become inline because it does not know that
some of them had been deferred.

Without this patch:

    Footnote^[footnote *with* stuff ]

With this patch:

    Footnote[^id]

    [^id]: footnote *with* stuff

Where the later is how to the original markdown file was formatted.

Signed-off-by: Miek Gieben <miek@miek.nl>