### PR TITLE
Add non-blocking-space

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ implements the following extensions:
 *   **Hard line breaks**. With this extension enabled newlines in the input
     translate into line breaks in the output. This extension is off by default.
 
+*   **Non blocking space**. With this extension enabled spaces preceeded by an backslash n the input
+    translate non-blocking spaces in the output. This extension is off by default.
+
 *   **Smart quotes**. Smartypants-style punctuation substitution is
     supported, turning normal double- and single-quote marks into
     curly quotes, etc.

--- a/ast/node.go
+++ b/ast/node.go
@@ -313,6 +313,11 @@ type Hardbreak struct {
 	Leaf
 }
 
+// NonBlockingSpace represents markdown non-blocking space node
+type NonBlockingSpace struct {
+	Leaf
+}
+
 // Code represents markdown code node
 type Code struct {
 	Leaf

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -446,6 +446,10 @@ func (r *Renderer) hardBreak(w io.Writer, node *ast.Hardbreak) {
 	r.cr(w)
 }
 
+func (r *Renderer) nonBlockingSpace(w io.Writer, node *ast.NonBlockingSpace) {
+	r.outs(w, "&nbsp;")
+}
+
 func (r *Renderer) outOneOf(w io.Writer, outFirst bool, first string, second string) {
 	if outFirst {
 		r.outs(w, first)
@@ -924,6 +928,8 @@ func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.Wal
 		// TODO: make it configurable via out(renderer.softbreak)
 	case *ast.Hardbreak:
 		r.hardBreak(w, node)
+	case *ast.NonBlockingSpace:
+		r.nonBlockingSpace(w, node)
 	case *ast.Emph:
 		r.outOneOf(w, entering, "<em>", "</em>")
 	case *ast.Strong:

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -695,6 +695,10 @@ func escape(p *Parser, data []byte, offset int) (int, ast.Node) {
 		return 2, nil
 	}
 
+	if p.extensions&NonBlockingSpace != 0 && data[1] == ' ' {
+		return 2, &ast.NonBlockingSpace{}
+	}
+
 	if p.extensions&BackslashLineBreak != 0 && data[1] == '\n' {
 		return 2, &ast.Hardbreak{}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -27,6 +27,7 @@ const (
 	LaxHTMLBlocks                                 // Loosen up HTML block parsing rules
 	SpaceHeadings                                 // Be strict about prefix heading rules
 	HardLineBreak                                 // Translate newlines into line breaks
+	NonBlockingSpace                              // Translate backspace spaces into line non-blocking spaces
 	TabSizeEight                                  // Expand tabs to eight spaces instead of four
 	Footnotes                                     // Pandoc-style footnotes
 	NoEmptyLineBeforeBlock                        // No need to insert an empty line to start a (code, quote, ordered list, unordered list) block


### PR DESCRIPTION
A backslash-space is a non-blocking-space that is recognized when
enabling the NonBlockingSpace extension.

Fixes: #128