### PR TITLE
md: Do not panic in when render image

### DIFF
--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -331,7 +331,6 @@ func (r *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.Wal
 		panic(fmt.Sprintf("node %T NYI", node))
 	case *ast.Image:
 		r.image(w, node)
-		panic(fmt.Sprintf("node %T NYI", node))
 	case *ast.Code:
 		r.code(w, node)
 	case *ast.CodeBlock:


### PR DESCRIPTION
Thanks for the awesome project. I was trying to render markdown with the `md` package and found that my code panics if it contains image, which then led me to finding this...

Hope the panic was not intentional.