### PR TITLE
Fix overriding reference text for custom references

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -37,6 +37,9 @@ func TestReferenceOverride(t *testing.T) {
 
 		"test [ref5][]\n",
 		"<p>test <a href=\"http://www.ref5.com/\" title=\"Reference 5\">Moo</a></p>\n",
+
+		"test [ref6]\n",
+		"<p>test <a href=\"http://www.ref6.com/\" title=\"Reference 6\">Moo</a></p>\n",
 	}
 	doTestsInlineParam(t, tests, TestParams{
 		referenceOverride: func(reference string) (rv *parser.Reference, overridden bool) {
@@ -65,6 +68,12 @@ func TestReferenceOverride(t *testing.T) {
 				return &parser.Reference{
 					Link:  "http://www.ref5.com/",
 					Title: "Reference 5",
+					Text:  "Moo",
+				}, true
+			case "ref6":
+				return &parser.Reference{
+					Link:  "http://www.ref6.com/",
+					Title: "Reference 6",
 					Text:  "Moo",
 				}, true
 			}

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -536,6 +536,9 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 			// if inline footnote, title == footnote contents
 			title = lr.title
 			noteID = lr.noteID
+			if len(lr.text) > 0 {
+				altContent = lr.text
+			}
 		}
 
 		// rewind the whitespace


### PR DESCRIPTION
I need this in order to be able to use `ReferenceOverride` for custom links, like `[some-page-identifier]` where the link text needs to be overridden.