### PR TITLE
Sup sub

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -1183,7 +1183,7 @@ func TestInlineMath(t *testing.T) {
 func TestSubSuper(t *testing.T) {
 	var tests = []string{
 		"H~2~O is a liquid, 2^10^ is 1024\n",
-		"<p><sub>2</sub>O is a liquid, 2<sup>10</sup> is 1024</p>\n",
+		"<p>H<sub>2</sub>O is a liquid, 2<sup>10</sup> is 1024</p>\n",
 		"2^10^ is 1024, H~2~O is a liquid\n",
 		"<p>2<sup>10</sup> is 1024, H<sub>2</sub>O is a liquid</p>\n",
 	}

--- a/inline_test.go
+++ b/inline_test.go
@@ -1180,6 +1180,16 @@ func TestInlineMath(t *testing.T) {
 	}, TestParams{Flags: html.SkipHTML, extensions: parser.CommonExtensions})
 }
 
+func TestSubSuper(t *testing.T) {
+	var tests = []string{
+		"H~2~O is a liquid, 2^10^ is 1024\n",
+		"<p><sub>2</sub>O is a liquid, 2<sup>10</sup> is 1024</p>\n",
+		"2^10^ is 1024, H~2~O is a liquid\n",
+		"<p>2<sup>10</sup> is 1024, H<sub>2</sub>O is a liquid</p>\n",
+	}
+	doTestsInlineParam(t, tests, TestParams{extensions: parser.SuperSubscript})
+}
+
 func BenchmarkSmartDoubleQuotes(b *testing.B) {
 	params := TestParams{Flags: html.Smartypants}
 	params.extensions |= parser.Autolink | parser.Strikethrough

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -228,7 +228,7 @@ func maybeInlineFootnoteOrSuper(p *Parser, data []byte, offset int) (int, ast.No
 		}
 		sup := &ast.Superscript{}
 		sup.Literal = data[offset+1 : offset+ret]
-		return offset + ret, sup
+		return ret + 1, sup
 	}
 
 	return 0, nil


### PR DESCRIPTION
Fix superscript
    
The code returned a new offset instead of the bytes consumed, fix this and add a test to test for it in inline_test.go
    
Signed-off-by: Miek Gieben <miek@miek.nl>
