### PR TITLE
html/doc.go: fix RenderOptions -> RendererOptions

### DIFF
--- a/html/doc.go
+++ b/html/doc.go
@@ -8,7 +8,7 @@ A renderer can be configured with multiple options:
 	import "github.com/gomarkdown/markdown/html"
 
 	flags := html.CommonFlags | html.CompletePage | html.HrefTargetBlank
-	opts := html.RenderOptions{
+	opts := html.RendererOptions{
 		TItle: "A custom title",
 		Flags: flags,
 	}


### PR DESCRIPTION
Fix misnomer in sample code in html docs.