### PR TITLE
Add '^' to escapeChars

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -1186,6 +1186,8 @@ func TestSubSuper(t *testing.T) {
 		"<p>H<sub>2</sub>O is a liquid, 2<sup>10</sup> is 1024</p>\n",
 		"2^10^ is 1024, H~2~O is a liquid\n",
 		"<p>2<sup>10</sup> is 1024, H<sub>2</sub>O is a liquid</p>\n",
+		"2\\^10 is 2^10^ is 1024\n",
+		"<p>2^10 is 2<sup>10</sup> is 1024</p>\n",
 	}
 	doTestsInlineParam(t, tests, TestParams{extensions: parser.SuperSubscript})
 }

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -689,7 +689,7 @@ func leftAngle(p *Parser, data []byte, offset int) (int, ast.Node) {
 }
 
 // '\\' backslash escape
-var escapeChars = []byte("\\`*_{}[]()#+-.!:|&<>~")
+var escapeChars = []byte("\\`*_{}[]()#+-.!:|&<>~^")
 
 func escape(p *Parser, data []byte, offset int) (int, ast.Node) {
 	data = data[offset:]


### PR DESCRIPTION
Add ^ because it will be detected for <sup>. Not the <sup> is an
extension but because of the `var escapeChars =` this can't be checked
at that point; I think this adding it can't do any harm.

Extend the test case a little for specially this case.

See https://github.com/mmarkdown/mmark/issues/104 for some background.