### PR TITLE
Add NoopenerLinks

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -28,6 +28,7 @@ const (
 	Safelink                                  // Only link to trusted protocols
 	NofollowLinks                             // Only link with rel="nofollow"
 	NoreferrerLinks                           // Only link with rel="noreferrer"
+	NoopenerLinks                             // Only link with rel="noopener"
 	HrefTargetBlank                           // Add a blank target
 	CompletePage                              // Generate a complete HTML page
 	UseXHTML                                  // Generate XHTML output instead of HTML
@@ -294,6 +295,9 @@ func appendLinkAttrs(attrs []string, flags Flags, link []byte) []string {
 	}
 	if flags&NoreferrerLinks != 0 {
 		val = append(val, "noreferrer")
+	}
+	if flags&NoopenerLinks != 0 {
+		val = append(val, "noopener")
 	}
 	if flags&HrefTargetBlank != 0 {
 		attrs = append(attrs, `target="_blank"`)

--- a/inline_test.go
+++ b/inline_test.go
@@ -463,6 +463,17 @@ func TestRelAttrLink(t *testing.T) {
 	doTestsInlineParam(t, nofollownoreferrerTests, TestParams{
 		Flags: html.Safelink | html.NofollowLinks | html.NoreferrerLinks,
 	})
+
+	var noopenernoreferrerTests = []string{
+		"[foo](http://bar.com/foo/)\n",
+		"<p><a href=\"http://bar.com/foo/\" rel=\"noreferrer noopener\">foo</a></p>\n",
+
+		"[foo](/bar/)\n",
+		"<p><a href=\"/bar/\">foo</a></p>\n",
+	}
+	doTestsInlineParam(t, noopenernoreferrerTests, TestParams{
+		Flags: html.Safelink | html.NoopenerLinks | html.NoreferrerLinks,
+	})
 }
 
 func TestHrefTargetBlank(t *testing.T) {


### PR DESCRIPTION
`rel=noopener` is an important flag to use. See https://mathiasbynens.github.io/rel-noopener/