### PR TITLE
First contribution - Line Endings

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,1 @@
+golang.org/dl v0.0.0-20190829154251-82a15e2f2ead/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=

--- a/markdown.go
+++ b/markdown.go
@@ -3,6 +3,7 @@ package markdown
 import (
 	"bytes"
 	"io"
+	"strings"
 
 	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/html"
@@ -74,7 +75,8 @@ func Render(doc ast.Node, renderer Renderer) []byte {
 // If you pass nil for both, we use parser configured with parser.CommonExtensions
 // and html.Renderer configured with html.CommonFlags.
 func ToHTML(markdown []byte, p *parser.Parser, renderer Renderer) []byte {
-	doc := Parse(markdown, p)
+	markdownForAll := strings.Replace(string(markdown), "\r\n", "\n", -1)
+	doc := Parse([]byte(markdownForAll), p)
 	if renderer == nil {
 		opts := html.RendererOptions{
 			Flags: html.CommonFlags,

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -23,3 +23,12 @@ func TestDocument(t *testing.T) {
 	}
 	doTests(t, tests)
 }
+
+func TestLineEndings(t *testing.T) {
+	var tests = []string{
+		// https://github.com/gomarkdown/markdown/issues/154
+		"something else",
+		"<p>something else</p>\n",
+	}
+	doTests(t, tests)
+}

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -27,6 +27,18 @@ func TestDocument(t *testing.T) {
 func TestLineEndings(t *testing.T) {
 	var tests = []string{
 		// https://github.com/gomarkdown/markdown/issues/154
+		"\r\nsomething",
+		"<p>something</p>\n",
+
+		"\nsomething else",
+		"<p>something else</p>\n",
+
+		"something\r\n",
+		"<p>something</p>\n",
+
+		"something else\n",
+		"<p>something else</p>\n",
+
 		"something else",
 		"<p>something else</p>\n",
 	}


### PR DESCRIPTION
Line Endings with a new empty line are converted to Paragraphs. Without this fix, tags of the new lines were not closed properly and affect the next node.