### PR TITLE
Fix TOC overriding HeadingIDs

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -169,6 +169,7 @@ func TestBlockComments(t *testing.T) {
 func TestTOC(t *testing.T) {
 	tests := readTestFile2(t, "TOC.tests")
 	doTestsParam(t, tests, TestParams{
+		extensions: parser.HeadingIDs,
 		Flags: html.UseXHTML | html.TOC,
 	})
 }

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -1114,7 +1114,9 @@ func (r *Renderer) writeTOC(w io.Writer, doc ast.Node) {
 				buf.WriteString("</a>")
 				return ast.GoToNext
 			}
-			nodeData.HeadingID = fmt.Sprintf("toc_%d", headingCount)
+			if nodeData.HeadingID == "" {
+				nodeData.HeadingID = fmt.Sprintf("toc_%d", headingCount)
+			}
 			if nodeData.Level == tocLevel {
 				buf.WriteString("</li>\n\n<li>")
 			} else if nodeData.Level < tocLevel {
@@ -1130,7 +1132,7 @@ func (r *Renderer) writeTOC(w io.Writer, doc ast.Node) {
 				}
 			}
 
-			fmt.Fprintf(&buf, `<a href="#toc_%d">`, headingCount)
+			fmt.Fprintf(&buf, `<a href="#%s">`, nodeData.HeadingID)
 			headingCount++
 			return ast.GoToNext
 		}

--- a/testdata/TOC.tests
+++ b/testdata/TOC.tests
@@ -2,7 +2,7 @@
 
 ##Subtitle1
 
-##Subtitle2
+##Subtitle2 {#T2}
 +++
 <nav>
 
@@ -11,7 +11,7 @@
 <ul>
 <li><a href="#toc_1">Subtitle1</a></li>
 
-<li><a href="#toc_2">Subtitle2</a></li>
+<li><a href="#T2">Subtitle2</a></li>
 </ul></li>
 </ul>
 
@@ -21,7 +21,7 @@
 
 <h2 id="toc_1">Subtitle1</h2>
 
-<h2 id="toc_2">Subtitle2</h2>
+<h2 id="T2">Subtitle2</h2>
 +++
 # Title
 


### PR DESCRIPTION
If you enable HeadingIDs, e.g. 

    ## Header Thing {#header-thing}

And also want to output TOC, the TOC will override your custom id and make generic `toc_<number>` ids instead.