### PR TITLE
lists in lists: make it contain a block element

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -1632,6 +1632,7 @@ gatherlines:
 			if indent <= itemIndent {
 				if p.listTypeChanged(chunk, flags) {
 					*flags |= ast.ListItemEndOfList
+					*flags |= ast.ListItemContainsBlock
 				} else if containsBlankLine {
 					*flags |= ast.ListItemContainsBlock
 				}

--- a/testdata/NestedDefinitionList.tests
+++ b/testdata/NestedDefinitionList.tests
@@ -43,7 +43,7 @@ Next line</p></dd>
 
 <dl>
 <dt>Term 11</dt>
-<dd>Definition c</dd>
+<dd><p>Definition c</p></dd>
 </dl>
 
 <ul>


### PR DESCRIPTION
block elements are detected by an empty line, but a list is also a block
element, so if we detect a list change (in list) we also set the
`ListItemContainsBlock` to true.

This parses all tests with a minimal change - I think it's the correct
way of doing this.

Signed-off-by: Miek Gieben <miek@miek.nl>