### PR TITLE
Added HR literal support

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -237,8 +237,10 @@ func (p *Parser) block(data []byte) {
 		// or
 		// ______
 		if p.isHRule(data) {
-			p.addBlock(&ast.HorizontalRule{})
 			i := skipUntilChar(data, 0, '\n')
+			hr := ast.HorizontalRule{}
+			hr.Literal = bytes.Trim(data[:i], " \n")
+			p.addBlock(&hr)
 			data = data[i:]
 			continue
 		}


### PR DESCRIPTION
I added a few lines so that custom renderHooks can detect which kind of horizontal rule was used.
This change does not in any way affect how the HR is rendered normally.