### PR TITLE
use t.Run() to make it easier to only run a subset of the testdata

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -113,29 +113,31 @@ func transformLinks(tests []string, prefix string) []string {
 func doTestsReference(t *testing.T, files []string, flag parser.Extensions) {
 	params := TestParams{extensions: flag}
 	for _, basename := range files {
-		filename := filepath.Join("testdata", basename+".text")
-		inputBytes, err := ioutil.ReadFile(filename)
-		if err != nil {
-			t.Errorf("Couldn't open '%s', error: %v\n", filename, err)
-			continue
-		}
-		inputBytes = normalizeNewlines(inputBytes)
-		input := string(inputBytes)
+		t.Run(basename, func(t *testing.T) {
+			filename := filepath.Join("testdata", basename+".text")
+			inputBytes, err := ioutil.ReadFile(filename)
+			if err != nil {
+				t.Errorf("Couldn't open '%s', error: %v\n", filename, err)
+				return
+			}
+			inputBytes = normalizeNewlines(inputBytes)
+			input := string(inputBytes)
 
-		filename = filepath.Join("testdata", basename+".html")
-		expectedBytes, err := ioutil.ReadFile(filename)
-		if err != nil {
-			t.Errorf("Couldn't open '%s', error: %v\n", filename, err)
-			continue
-		}
-		expectedBytes = normalizeNewlines(expectedBytes)
-		expected := string(expectedBytes)
+			filename = filepath.Join("testdata", basename+".html")
+			expectedBytes, err := ioutil.ReadFile(filename)
+			if err != nil {
+				t.Errorf("Couldn't open '%s', error: %v\n", filename, err)
+				return
+			}
+			expectedBytes = normalizeNewlines(expectedBytes)
+			expected := string(expectedBytes)
 
-		actual := string(runMarkdown(input, params))
-		if actual != expected {
-			t.Errorf("\n    [%#v]\nExpected[%#v]\nActual  [%#v]",
-				basename+".text", expected, actual)
-		}
+			actual := string(runMarkdown(input, params))
+			if actual != expected {
+				t.Errorf("\n    [%#v]\nExpected[%#v]\nActual  [%#v]",
+					basename+".text", expected, actual)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
when you run tests with this change it will look like this;

```
--- PASS: TestReference (0.05s)
    --- PASS: TestReference/Amps_and_angle_encoding (0.00s)
    --- PASS: TestReference/Auto_links (0.00s)
    --- PASS: TestReference/Backslash_escapes (0.00s)
    --- PASS: TestReference/Blockquotes_with_code_blocks (0.00s)
    --- PASS: TestReference/Code_Blocks (0.00s)
    --- PASS: TestReference/Code_Spans (0.00s)
    --- PASS: TestReference/Horizontal_rules (0.00s)
    --- PASS: TestReference/Inline_HTML_(Advanced) (0.00s)
    --- PASS: TestReference/Inline_HTML_(Simple) (0.00s)
    --- PASS: TestReference/Inline_HTML_comments (0.00s)
    --- PASS: TestReference/Links,_inline_style (0.00s)
    --- PASS: TestReference/Links,_reference_style (0.00s)
    --- PASS: TestReference/Links,_shortcut_references (0.00s)
    --- PASS: TestReference/Literal_quotes_in_titles (0.00s)
    --- PASS: TestReference/Markdown_Documentation_-_Basics (0.00s)
    --- PASS: TestReference/Markdown_Documentation_-_Syntax (0.00s)
    --- PASS: TestReference/Nested_blockquotes (0.00s)
    --- PASS: TestReference/Ordered_and_unordered_lists (0.03s)
    --- PASS: TestReference/Strong_and_em_together (0.00s)
    --- PASS: TestReference/Tabs (0.00s)
    --- PASS: TestReference/Tidyness (0.00s)
    --- PASS: TestReference/Hard-wrapped_paragraphs_with_list-like_lines (0.00s)
```

and you can easily run only a specific test by doing for example `go test ./... -run=TestReference/Tidyness`