### PR TITLE
Parse headless table

### DIFF
--- a/testdata/Table.tests
+++ b/testdata/Table.tests
@@ -258,3 +258,15 @@ j|k|l|m
 </tr>
 </tfoot>
 </table>
++++
+---|---
+c | d
++++
+<table>
+<tbody>
+<tr>
+<td>c</td>
+<td>d</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
this will parse a table without a header row as well, for example:

```
---|---
 c | d
```