### PR TITLE
add support for RenderNodeHook to add additional attributes to links.

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -250,11 +250,12 @@ type Del struct {
 type Link struct {
 	Container
 
-	Destination []byte // Destination is what goes into a href
-	Title       []byte // Title is the tooltip thing that goes in a title attribute
-	NoteID      int    // NoteID contains a serial number of a footnote, zero if it's not a footnote
-	Footnote    Node   // If it's a footnote, this is a direct link to the footnote Node. Otherwise nil.
-	DeferredID  []byte // If a deferred link this holds the original ID.
+	Destination          []byte   // Destination is what goes into a href
+	Title                []byte   // Title is the tooltip thing that goes in a title attribute
+	NoteID               int      // NoteID contains a serial number of a footnote, zero if it's not a footnote
+	Footnote             Node     // If it's a footnote, this is a direct link to the footnote Node. Otherwise nil.
+	DeferredID           []byte   // If a deferred link this holds the original ID.
+	AdditionalAttributes []string // Defines additional attributes to use during rendering.
 }
 
 // CrossReference is a reference node.

--- a/html/renderer.go
+++ b/html/renderer.go
@@ -537,7 +537,7 @@ func (r *Renderer) HTMLSpan(w io.Writer, span *ast.HTMLSpan) {
 }
 
 func (r *Renderer) linkEnter(w io.Writer, link *ast.Link) {
-	var attrs []string
+	attrs := link.AdditionalAttributes
 	dest := link.Destination
 	dest = r.addAbsPrefix(dest)
 	var hrefBuf bytes.Buffer

--- a/html_renderer_test.go
+++ b/html_renderer_test.go
@@ -54,3 +54,26 @@ func TestRenderNodeHookCode(t *testing.T) {
 	}
 	doTestsParam(t, tests, params)
 }
+
+func TestRenderNodeHookLinkAttrs(t *testing.T) {
+	tests := []string{
+		`[Click Me](gopher://foo.bar "Click Me")`,
+		`<p><a class="button" href="gopher://foo.bar" target="_blank" title="Click Me">Click Me</a></p>` + "\n",
+	}
+	opts := html.RendererOptions{
+		RenderNodeHook: func(w io.Writer, node ast.Node, entering bool) (ast.WalkStatus, bool) {
+			link, isLink := node.(*ast.Link)
+			if isLink {
+				link.AdditionalAttributes = append(link.AdditionalAttributes, `class="button"`)
+			}
+
+			return ast.GoToNext, false
+		},
+	}
+	params := TestParams{
+		Flags:          html.HrefTargetBlank,
+		RendererOptions: opts,
+		extensions:      parser.CommonExtensions,
+	}
+	doTestsParam(t, tests, params)
+}


### PR DESCRIPTION
as an alternative to https://github.com/gomarkdown/markdown/pull/176 this PR adds a way to add additional attributes to links which the HTML renderer will include when rendering the link.