### PR TITLE
Add LazyLoadImages flag

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -43,6 +43,7 @@ const (
 	SmartypantsAngledQuotes                   // Enable angled double quotes (with Smartypants) for double quotes rendering
 	SmartypantsQuotesNBSP                     // Enable « French guillemets » (with Smartypants)
 	TOC                                       // Generate a table of contents
+	LazyLoadImages                            // Include loading="lazy" with images
 
 	CommonFlags Flags = Smartypants | SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
 )
@@ -589,7 +590,11 @@ func (r *Renderer) imageEnter(w io.Writer, image *ast.Image) {
 		//if options.safe && potentiallyUnsafe(dest) {
 		//out(w, `<img src="" alt="`)
 		//} else {
-		r.Outs(w, `<img src="`)
+		if r.opts.Flags&LazyLoadImages != 0 {
+			r.Outs(w, `<img loading="lazy" src="`)
+		} else {
+			r.Outs(w, `<img src="`)
+		}
 		escLink(w, dest)
 		r.Outs(w, `" alt="`)
 		//}

--- a/inline_test.go
+++ b/inline_test.go
@@ -1165,6 +1165,15 @@ func TestSkipImages(t *testing.T) {
 	})
 }
 
+func TestLazyLoadImages(t *testing.T) {
+	doTestsInlineParam(t, []string{
+		"![foo](/bar/)\n",
+		"<p><img loading=\"lazy\" src=\"/bar/\" alt=\"foo\" /></p>\n",
+	}, TestParams{
+		Flags: html.LazyLoadImages,
+	})
+}
+
 func TestUseXHTML(t *testing.T) {
 	doTestsParam(t, []string{
 		"---",


### PR DESCRIPTION
I use gomarkdown/markdown for server side rendering, and I was initially going to create a custom renderer to stop the server-side rendering result from actually lazy loading images on the front end (because the front end supported lazy loading while the back end didn't), but I figured this flag could come in handy for others.

Basically, setting this new `LazyLoadImages` flag would automatically include `loading="lazy"` in `img` elements.

For more context on what this does: https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading