### PR TITLE
Fix panic with table parsing

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -1221,7 +1221,7 @@ func (p *Parser) tableRow(data []byte, columns []ast.CellAlignFlags, header bool
 
 		// skip the end-of-cell marker, possibly taking us past end of buffer
 		// each _extra_ | means a colspan
-		for data[i] == '|' && !isBackslashEscaped(data, i) {
+		for i < len(data) && data[i] == '|' && !isBackslashEscaped(data, i) {
 			i++
 			colspan++
 		}

--- a/testdata/Table.tests
+++ b/testdata/Table.tests
@@ -296,3 +296,22 @@ h|i|j
 </tr>
 </tbody>
 </table>
++++
+| a | b |
+|---|---|
+| | |+++
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td></td>
+<td></td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
If a table is the last thing in the file, and there's no terminating newline
in the file, the parser will try to read past the end of the byte slice,
leading to a panic. This fixes the problem and adds a test which illustrates
the problem.