### PR TITLE
Check for caption after (code)include

### DIFF
--- a/parser/block_table.go
+++ b/parser/block_table.go
@@ -284,7 +284,7 @@ func (p *Parser) table(data []byte) int {
 
 		p.tableRow(data[rowStart:i], columns, false)
 	}
-	if captionContent, id, consumed := p.caption(data[i:], []byte("Table: ")); consumed > 0 {
+	if captionContent, id, consumed := p.caption(data[i:], []byte(captionTable)); consumed > 0 {
 		caption := &ast.Caption{}
 		p.Inline(caption, captionContent)
 


### PR DESCRIPTION
Codeblocks, tables and quotes may include a caption, we need to check
for this at parse time and adjust the bytes read. If not there is a
weird disconnect between "doing it inline" and using it via an include.

Take this small md file:

~~~ markdown
<{{testdata/includes.c}}
Figure: A sample function.

And some other text.
~~~

Before:

~~~
CodeBlock 'main() int {\n        return 0\n}\n'
Paragraph
  Text 'Figure: A sample function.'
Paragraph
  Text 'And some other text.'
~~~

After:

~~~
CaptionFigure
  CodeBlock 'main() int {\n        return 0\n}\n'
  Caption
    Text 'A sample function.\n'
Paragraph
  Text 'And some other text.'
~~~

which will then do the right thing. Make 'Figure: ", etc. constants as
they are used more than once.

Signed-off-by: Miek Gieben <miek@miek.nl>
