### PR TITLE
Allow ) as delimiter in ordered lists

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -1206,7 +1206,7 @@ func (p *Parser) oliPrefix(data []byte) int {
 	}
 
 	// we need >= 1 digits followed by a dot and a space or a tab
-	if data[i] != '.' || !(data[i+1] == ' ' || data[i+1] == '\t') {
+	if data[i] != '.' && data[i] != ')' || !(data[i+1] == ' ' || data[i+1] == '\t') {
 		return 0
 	}
 	return i + 2
@@ -1321,10 +1321,16 @@ func (p *Parser) listItem(data []byte, flags *ast.ListType) int {
 		}
 	}
 
-	var bulletChar byte = '*'
+	var (
+		bulletChar byte = '*'
+		delimiter  byte = '.'
+	)
 	i := p.uliPrefix(data)
 	if i == 0 {
 		i = p.oliPrefix(data)
+		if i > 0 {
+			delimiter = data[i-2]
+		}
 	} else {
 		bulletChar = data[i-2]
 	}
@@ -1484,7 +1490,7 @@ gatherlines:
 		ListFlags:  *flags,
 		Tight:      false,
 		BulletChar: bulletChar,
-		Delimiter:  '.', // Only '.' is possible in Markdown, but ')' will also be possible in CommonMark
+		Delimiter:  delimiter,
 	}
 	p.addBlock(listItem)
 

--- a/testdata/OrderedList.tests
+++ b/testdata/OrderedList.tests
@@ -53,14 +53,14 @@
 +++
 <p>1.Hello</p>
 +++
-1.  Hello 
+1.  Hello
 +++
 <ol>
 <li>Hello</li>
 </ol>
 +++
-1.  Hello 
-    Next line 
+1.  Hello
+    Next line
 +++
 <ol>
 <li>Hello
@@ -248,4 +248,12 @@ Second line</p>
 <ol>
 <li>numbers</li>
 <li>are ignored</li>
+</ol>
++++
+1) parentheses
+2) are supported
++++
+<ol>
+<li>parentheses</li>
+<li>are supported</li>
 </ol>


### PR DESCRIPTION
This is allowed in commonmark and there is actually a comment in the
source saying so much.

Add check to oliPrefix to check for ) and in the list-gathering function
set the delimiter found.

Signed-off-by: Miek Gieben <miek@miek.nl>
