### PR TITLE
Make tables break a paragraph

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -1672,6 +1672,14 @@ func (p *Parser) paragraph(data []byte) int {
 			}
 		}
 
+		// if there's a table, paragraph is over
+		if p.extensions&Tables != 0 {
+			if j, _, _ := p.tableHeader(current, false); j > 0 {
+				p.renderParagraph(data[:i])
+				return i
+			}
+		}
+
 		// if there's a definition list item, prev line is a definition term
 		if p.extensions&DefinitionLists != 0 {
 			if p.dliPrefix(current) != 0 {

--- a/parser/block_table.go
+++ b/parser/block_table.go
@@ -105,7 +105,7 @@ func (p *Parser) tableFooter(data []byte) bool {
 }
 
 // tableHeaders parses the header. If recognized it will also add a table.
-func (p *Parser) tableHeader(data []byte) (size int, columns []ast.CellAlignFlags, table ast.Node) {
+func (p *Parser) tableHeader(data []byte, doRender bool) (size int, columns []ast.CellAlignFlags, table ast.Node) {
 	i := 0
 	colCount := 1
 	headerIsUnderline := true
@@ -236,11 +236,13 @@ func (p *Parser) tableHeader(data []byte) (size int, columns []ast.CellAlignFlag
 		return
 	}
 
-	table = &ast.Table{}
-	p.addBlock(table)
-	if header != nil {
-		p.addBlock(&ast.TableHeader{})
-		p.tableRow(header, columns, true)
+	if doRender {
+		table = &ast.Table{}
+		p.addBlock(table)
+		if header != nil {
+			p.addBlock(&ast.TableHeader{})
+			p.tableRow(header, columns, true)
+		}
 	}
 	size = skipCharN(data, i, '\n', 1)
 	return
@@ -255,7 +257,7 @@ Bob   | 31  | 555-1234
 Alice | 27  | 555-4321
 */
 func (p *Parser) table(data []byte) int {
-	i, columns, table := p.tableHeader(data)
+	i, columns, table := p.tableHeader(data, true)
 	if i == 0 {
 		return 0
 	}

--- a/testdata/Table.tests
+++ b/testdata/Table.tests
@@ -334,3 +334,25 @@ h|i|j
 </tr>
 </tbody>
 </table>
++++
+prefix text
+| a | b |
+|---|---|
+| | |+++
+<p>prefix text</p>
+
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td></td>
+<td></td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
Tables are block level entities and as such should also break a
paragraph, just like lists, codeblocks, etc.

Add the missing the check in the paragraph() function. Needed to alter
the tableHeader() function to not added a TableHeader if detected, added
doRender bool for that.

testdata/Tables.tests extended with a test that has text before the
table and double checked it failed without the new code.

Fixes: #214

Signed-off-by: Miek Gieben <miek@miek.nl>
