### PR TITLE
Fix codespan inside a table

### DIFF
--- a/parser/block_table.go
+++ b/parser/block_table.go
@@ -25,6 +25,11 @@ func (p *Parser) tableRow(data []byte, columns []ast.CellAlignFlags, header bool
 
 		cellStart := i
 
+		// If we are in a codespan we should discount any | we see, check for that here and skip ahead.
+		if isCode, _ := codeSpan(p, data[i:], 0); isCode > 0 {
+			i += isCode - 1
+		}
+
 		for i < n && (data[i] != '|' || isBackslashEscaped(data, i)) && data[i] != '\n' {
 			i++
 		}
@@ -84,6 +89,11 @@ func (p *Parser) tableFooter(data []byte) bool {
 	n := len(data)
 	i := skipCharN(data, 0, ' ', 3)
 	for ; i < n && data[i] != '\n'; i++ {
+		// If we are in a codespan we should discount any | we see, check for that here and skip ahead.
+		if isCode, _ := codeSpan(p, data[i:], 0); isCode > 0 {
+			i += isCode - 1
+		}
+
 		if data[i] == '|' && !isBackslashEscaped(data, i) {
 			colCount++
 			continue
@@ -111,6 +121,11 @@ func (p *Parser) tableHeader(data []byte, doRender bool) (size int, columns []as
 	headerIsUnderline := true
 	headerIsWithEmptyFields := true
 	for i = 0; i < len(data) && data[i] != '\n'; i++ {
+		// If we are in a codespan we should discount any | we see, check for that here and skip ahead.
+		if isCode, _ := codeSpan(p, data[i:], 0); isCode > 0 {
+			i += isCode - 1
+		}
+
 		if data[i] == '|' && !isBackslashEscaped(data, i) {
 			colCount++
 		}

--- a/testdata/Table.tests
+++ b/testdata/Table.tests
@@ -356,3 +356,67 @@ prefix text
 </tr>
 </tbody>
 </table>
++++
+| a | `b|c` |
+|---|---|
+| | |+++
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th><code>b|c</code></th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td></td>
+<td></td>
+</tr>
+</tbody>
+</table>
++++
+---|---
+c | `d|e`
++++
+<table>
+<tbody>
+<tr>
+<td>c</td>
+<td><code>d|e</code></td>
+</tr>
+</tbody>
+</table>
++++
+|---|--- |
+| c  | `d|e` |
++++
+<table>
+<tbody>
+<tr>
+<td>c</td>
+<td><code>d|e</code></td>
+</tr>
+</tbody>
+</table>
++++
+|---|--- |
+| c  | `d|e` |
+|===|====|
+| `f|g` | h |
++++
+<table>
+<tbody>
+<tr>
+<td>c</td>
+<td><code>d|e</code></td>
+</tr>
+</tbody>
+
+<tfoot>
+<tr>
+<td><code>f|g</code></td>
+<td>h</td>
+</tr>
+</tfoot>
+</table>


### PR DESCRIPTION
A codespan can contain a `|`. This messes up the table parsing because
the delimiter there is also `|`. Check for a codespan in the table
(header, row or footer) and simply skip to the end of it and resume scanning.

Signed-off-by: Miek Gieben <miek@miek.nl>

table footer

Signed-off-by: Miek Gieben <miek@miek.nl>
