### PR TITLE
Fix fenced codeblocks inside lists

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -270,6 +270,20 @@ func TestCodeSpan(t *testing.T) {
 	doTestsInlineParam(t, tests, tp)
 }
 
+func TestCodeBlock(t *testing.T) {
+	var tests = []string{
+		"1. This is an item\n" +
+			"   ```java\n" +
+			"   int a = 1;\n" +
+			"   ```\n" +
+			"1. This is another item\n",
+		"<ol>\n<li>This is an item\n\n<pre><code class=\"language-java\">\nint a = 1;\n</code></pre>\n</li>\n<li>This is another item</li>\n</ol>\n",
+	}
+	doTestsInlineParam(t, tests, TestParams{
+		extensions: parser.FencedCode,
+	})
+}
+
 func TestLineBreak(t *testing.T) {
 	var tests = []string{
 		"this line  \nhas a break\n",

--- a/inline_test.go
+++ b/inline_test.go
@@ -810,9 +810,11 @@ No longer in the footnote
 
 <p>Paragraph 2</p>
 
-<p><code>
+<p>
+<pre><code>
 some code
-</code></p>
+</code></pre>
+</p>
 
 <p>Paragraph 3</p></li>
 </ol>

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -131,7 +131,11 @@ func codeSpan(p *Parser, data []byte, offset int) (int, ast.Node) {
 
 	// find the next delimiter
 	i, end := 0, 0
+	hasLFBeforeDelimiter := false
 	for end = nb; end < len(data) && i < nb; end++ {
+		if data[end] == '\n' {
+			hasLFBeforeDelimiter = true
+		}
 		if data[end] == '`' {
 			i++
 		} else {
@@ -142,6 +146,18 @@ func codeSpan(p *Parser, data []byte, offset int) (int, ast.Node) {
 	// no matching delimiter?
 	if i < nb && end >= len(data) {
 		return 0, nil
+	}
+
+	// If there are non-space chars after the ending delimiter and before a '\n',
+	// flag that this is not a well formed fenced code block.
+	hasCharsAfterDelimiter := false
+	for j := end; j < len(data); j++ {
+		if data[j] == '\n' {
+			break
+		}
+		if !isSpace(data[j]) {
+			hasCharsAfterDelimiter = true
+		}
 	}
 
 	// trim outside whitespace
@@ -155,14 +171,31 @@ func codeSpan(p *Parser, data []byte, offset int) (int, ast.Node) {
 		fEnd--
 	}
 
-	// render the code span
-	if fBegin != fEnd {
-		code := &ast.Code{}
-		code.Literal = data[fBegin:fEnd]
-		return end, code
+	if fBegin == fEnd {
+		return end, nil
 	}
 
-	return end, nil
+	// if delimiter has 3 backticks
+	if nb == 3 {
+		i := fBegin
+		syntaxStart, syntaxLen := syntaxRange(data, &i)
+
+		// If we found a '\n' before the end marker and there are only spaces
+		// after the end marker, then this is a code block.
+		if hasLFBeforeDelimiter && !hasCharsAfterDelimiter {
+			codeblock := &ast.CodeBlock{
+				IsFenced: true,
+				Info:     data[syntaxStart : syntaxStart+syntaxLen],
+			}
+			codeblock.Literal = data[i:fEnd]
+			return end, codeblock
+		}
+	}
+
+	// render the code span
+	code := &ast.Code{}
+	code.Literal = data[fBegin:fEnd]
+	return end, code
 }
 
 // newline preceded by two spaces becomes <br>

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -781,7 +781,7 @@ func entity(p *Parser, data []byte, offset int) (int, ast.Node) {
 		codepoint, err = strconv.ParseUint(string(ent[2:len(ent)-1]), 10, 64)
 	}
 	if err == nil { // only if conversion was valid return here.
-		return end, newTextNode([]byte(string(codepoint)))
+		return end, newTextNode([]byte(string(rune(codepoint))))
 	}
 
 	return end, newTextNode(ent)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -52,7 +52,7 @@ func TestIsFenceLine(t *testing.T) {
 		if test.syntaxRequested {
 			syntax = new(string)
 		}
-		end, marker := isFenceLine(test.data, syntax, "```")
+		end, marker := isFenceLine(test.data, syntax, "")
 		if got, want := end, test.wantEnd; got != want {
 			t.Errorf("got end %v, want %v", got, want)
 		}


### PR DESCRIPTION
Fixes https://github.com/gomarkdown/markdown/issues/124

There are a couple of tests that start failing when this PR is applied, but I think that actually the expected value must be updated. These are the tests that fails:

**TestFootnotes**
Input:
```md
        Input:
        testing long[^b] notes.
        
        [^b]: Paragraph 1
        
                Paragraph 2
        
                ```
                some code
                ```
        
                Paragraph 3
        
        No longer in the footnote
```

Expected: 
```html
        <p>testing long<sup class="footnote-ref" id="fnref:b"><a href="#fn:b">1</a></sup> notes.</p>
        
        <p>No longer in the footnote</p>
        
        <div class="footnotes">
        
        <hr />
        
        <ol>
        <li id="fn:b"><p>Paragraph 1</p>
        
        <p>Paragraph 2</p>
        
        <p><code>
        some code
        </code></p>
        
        <p>Paragraph 3</p></li>
        </ol>
        
        </div>
```

Got:
```html
        <p>testing long<sup class="footnote-ref" id="fnref:b"><a href="#fn:b">1</a></sup> notes.</p>
        
        <p>No longer in the footnote</p>
        
        <div class="footnotes">
        
        <hr />
        
        <ol>
        <li id="fn:b"><p>Paragraph 1</p>
        
        <p>Paragraph 2</p>
        
        <p>
        <pre><code>
        some code
        </code></pre>
        </p>
        
        <p>Paragraph 3</p></li>
        </ol>
        
        </div>
```

**TestFootnotesWithParameters**
Input:
```md
        testing long[^b] notes.
        
        [^b]: Paragraph 1
        
                Paragraph 2
        
                ```
                some code
                ```
        
                Paragraph 3
        
        No longer in the footnote
```

Expected:
```html
        <p>testing long<sup class="footnote-ref" id="fnref:testPrefixb"><a href="#fn:testPrefixb">1</a></sup> notes.</p>
        
        <p>No longer in the footnote</p>
        
        <div class="footnotes">
        
        <hr />
        
        <ol>
        <li id="fn:testPrefixb"><p>Paragraph 1</p>
        
        <p>Paragraph 2</p>
        
        <p><code>
        some code
        </code></p>
        
        <p>Paragraph 3</p> <a class="footnote-return" href="#fnref:testPrefixb">ret</a></li>
        </ol>
        
        </div>
```

Got:
```html
        <p>testing long<sup class="footnote-ref" id="fnref:testPrefixb"><a href="#fn:testPrefixb">1</a></sup> notes.</p>
        
        <p>No longer in the footnote</p>
        
        <div class="footnotes">
        
        <hr />
        
        <ol>
        <li id="fn:testPrefixb"><p>Paragraph 1</p>
        
        <p>Paragraph 2</p>
        
        <p>
        <pre><code>
        some code
        </code></pre>
        </p>
        
        <p>Paragraph 3</p> <a class="footnote-return" href="#fnref:testPrefixb">ret</a></li>
        </ol>
        
        </div>
```

If you think the expected value must be fixed, just let me know and I can push a commit with the fix.