### PR TITLE
Fix markdown rendering of heading

### DIFF
--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -254,6 +254,8 @@ func (r *Renderer) heading(w io.Writer, node *ast.Heading, entering bool) {
 		}
 		r.outs(w, " ")
 		r.out(w, node.Literal)
+	} else {
+		r.outs(w, "\n")
 	}
 }
 

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/gomarkdown/markdown/ast"
 )
 
+func TestRenderDocument(t *testing.T)  {
+        var source = []byte("# title\n* aaa\n* bbb\n* ccc")
+        var input = markdown.Parse(source, nil)
+        var expected = "# title\n* aaa\n* bbb\n* ccc\n"
+        testRendering(t, input, expected)
+}
+
 func TestRenderText(t *testing.T) {
 	var input ast.Node = &ast.Text{Leaf: ast.Leaf{Literal: []byte(string("Hello"))}}
 	expected := "Hello"
@@ -24,7 +31,7 @@ func TestRenderStrong(t *testing.T) {
 func TestRenderHeading(t *testing.T) {
 	var input ast.Node = &ast.Heading{Level: 3}
 	ast.AppendChild(input, &ast.Text{Leaf: ast.Leaf{Literal: []byte(string("Hello"))}})
-	expected := "### Hello"
+	expected := "### Hello\n"
         testRendering(t, input, expected)
 }
 


### PR DESCRIPTION
Fix the markdown rendering of the Heading. Basically, we always want a newline after outputting the heading text.