### PR TITLE
fix markdown html block rendering

### DIFF
--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -211,7 +211,7 @@ func (r *Renderer) htmlSpan(w io.Writer, node *ast.HTMLSpan) {
 func (r *Renderer) htmlBlock(w io.Writer, node *ast.HTMLBlock) {
 	r.doubleSpace(w)
 	r.out(w, node.Literal)
-	r.outs(w, "\n")
+	r.outs(w, "\n\n")
 }
 
 func (r *Renderer) codeBlock(w io.Writer, node *ast.CodeBlock) {

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -94,7 +94,7 @@ func TestRenderHTMLSpan(t *testing.T) {
 func TestRenderHTMLBlock(t *testing.T) {
 	var input = &ast.HTMLBlock{}
         input.Literal = []byte(string("hello"))
-        expected := "\nhello\n"
+        expected := "\nhello\n\n"
         testRendering(t, input, expected)
 }
 


### PR DESCRIPTION
Hello! Recently found that the markdown renderer renders html blocks incorrectly. According to [spec](https://daringfireball.net/projects/markdown/syntax#html) block level html must be separated from surrounding content by blank lines. Seems like my naive fix could help.

So, for example, this markdown:

# This is a regular paragraph.

<table>
    <tr>
        <td>Foo</td>
    </tr>
</table>

# This is another regular paragraph.

Renders as:

# This is a regular paragraph.

<table>
    <tr>
        <td>Foo</td>
    </tr>
</table>
# This is another regular paragraph.
