### PR TITLE
Move ValidUris and ValidPaths in a separate package

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -3,6 +3,7 @@ package html
 import (
 	"bytes"
 	"fmt"
+	"github.com/gomarkdown/markdown/internal/valid"
 	"html"
 	"io"
 	"regexp"
@@ -1225,12 +1226,8 @@ func isListItemTerm(node ast.Node) bool {
 	return ok && data.ListFlags&ast.ListTypeTerm != 0
 }
 
-// TODO: move to internal package
-var validUris = [][]byte{[]byte("http://"), []byte("https://"), []byte("ftp://"), []byte("mailto://")}
-var validPaths = [][]byte{[]byte("/"), []byte("./"), []byte("../")}
-
 func isSafeLink(link []byte) bool {
-	for _, path := range validPaths {
+	for _, path := range valid.Paths {
 		if len(link) >= len(path) && bytes.Equal(link[:len(path)], path) {
 			if len(link) == len(path) {
 				return true
@@ -1240,7 +1237,7 @@ func isSafeLink(link []byte) bool {
 		}
 	}
 
-	for _, prefix := range validUris {
+	for _, prefix := range valid.URIs {
 		// TODO: handle unicode here
 		// case-insensitive prefix test
 		if len(link) > len(prefix) && bytes.Equal(bytes.ToLower(link[:len(prefix)]), prefix) && isAlnum(link[len(prefix)]) {

--- a/inline_test.go
+++ b/inline_test.go
@@ -553,8 +553,8 @@ func TestSafeInlineLink(t *testing.T) {
 		"[foo](ftp://bar/)\n",
 		"<p><a href=\"ftp://bar/\">foo</a></p>\n",
 
-		"[foo](mailto://bar/)\n",
-		"<p><a href=\"mailto://bar/\">foo</a></p>\n",
+		"[foo](mailto:bar/)\n",
+		"<p><a href=\"mailto:bar/\">foo</a></p>\n",
 
 		// Not considered safe
 		"[foo](baz://bar/)\n",
@@ -707,8 +707,8 @@ func TestAutoLink(t *testing.T) {
 		"an email <mailto:some@one.com>\n",
 		"<p>an email <a href=\"mailto:some@one.com\">some@one.com</a></p>\n",
 
-		"an email <mailto://some@one.com>\n",
-		"<p>an email <a href=\"mailto://some@one.com\">some@one.com</a></p>\n",
+		"an email <mailto:some@one.com>\n",
+		"<p>an email <a href=\"mailto:some@one.com\">some@one.com</a></p>\n",
 
 		"an email <some@one.com>\n",
 		"<p>an email <a href=\"mailto:some@one.com\">some@one.com</a></p>\n",
@@ -1212,7 +1212,7 @@ func TestSkipLinks(t *testing.T) {
 		"[foo](gopher://foo.bar)",
 		"<p><tt>foo</tt></p>\n",
 
-		"[foo](mailto://bar/)\n",
+		"[foo](mailto:bar/)\n",
 		"<p><tt>foo</tt></p>\n",
 	}, TestParams{
 		Flags: html.SkipLinks,

--- a/internal/valid/valid.go
+++ b/internal/valid/valid.go
@@ -1,0 +1,14 @@
+package valid
+
+var URIs = [][]byte{
+	[]byte("http://"),
+	[]byte("https://"),
+	[]byte("ftp://"),
+	[]byte("mailto://"),
+}
+
+var Paths = [][]byte{
+	[]byte("/"),
+	[]byte("./"),
+	[]byte("../"),
+}

--- a/internal/valid/valid.go
+++ b/internal/valid/valid.go
@@ -4,7 +4,7 @@ var URIs = [][]byte{
 	[]byte("http://"),
 	[]byte("https://"),
 	[]byte("ftp://"),
-	[]byte("mailto://"),
+	[]byte("mailto:"),
 }
 
 var Paths = [][]byte{

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"github.com/gomarkdown/markdown/internal/valid"
 	"regexp"
 	"strconv"
 
@@ -994,12 +995,9 @@ func isEndOfLink(char byte) bool {
 	return isSpace(char) || char == '<'
 }
 
-var validUris = [][]byte{[]byte("http://"), []byte("https://"), []byte("ftp://"), []byte("mailto://")}
-var validPaths = [][]byte{[]byte("/"), []byte("./"), []byte("../")}
-
 func isSafeLink(link []byte) bool {
 	nLink := len(link)
-	for _, path := range validPaths {
+	for _, path := range valid.Paths {
 		nPath := len(path)
 		linkPrefix := link[:nPath]
 		if nLink >= nPath && bytes.Equal(linkPrefix, path) {
@@ -1011,7 +1009,7 @@ func isSafeLink(link []byte) bool {
 		}
 	}
 
-	for _, prefix := range validUris {
+	for _, prefix := range valid.URIs {
 		// TODO: handle unicode here
 		// case-insensitive prefix test
 		nPrefix := len(prefix)


### PR DESCRIPTION
The vars had duplicate content. I followed the wish expressed in the `TODO` and move them in a separate (internal) package. I also noticed that `mailto:` had slashes after the semicolon which made no sense.