### PR TITLE
Allow adding extra entries in the list of safe URIs

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -18,10 +18,16 @@ type TestParams struct {
 }
 
 func runMarkdown(input string, params TestParams) string {
+	extraUris := [][]byte{
+		[]byte("bitcoin:"),
+		[]byte("monero:"),
+	}
 	params.RendererOptions.Flags = params.Flags
 	parser := parser.NewWithExtensions(params.extensions)
 	parser.ReferenceOverride = params.referenceOverride
+	parser.AutoLinkExtraSafeURIs = extraUris
 	renderer := html.NewRenderer(params.RendererOptions)
+	renderer.AutoLinkExtraSafeURIs = extraUris
 
 	d := ToHTML([]byte(input), parser, renderer)
 	return string(d)

--- a/inline_test.go
+++ b/inline_test.go
@@ -556,6 +556,12 @@ func TestSafeInlineLink(t *testing.T) {
 		"[foo](mailto:bar/)\n",
 		"<p><a href=\"mailto:bar/\">foo</a></p>\n",
 
+		"[foo](monero:4AfUP827TeRZ1cck3tZThgZbRCEwBrpcJTkA1LCiyFVuMH4b5y59bKMZHGb9y58K3gSjWDCBsB4RkGsGDhsmMG5R2qmbLeW)\n",
+		"<p><a href=\"monero:4AfUP827TeRZ1cck3tZThgZbRCEwBrpcJTkA1LCiyFVuMH4b5y59bKMZHGb9y58K3gSjWDCBsB4RkGsGDhsmMG5R2qmbLeW\">foo</a></p>\n",
+
+		"[foo](bitcoin:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh)\n",
+		"<p><a href=\"bitcoin:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh\">foo</a></p>\n",
+
 		// Not considered safe
 		"[foo](baz://bar/)\n",
 		"<p><tt>foo</tt></p>\n",

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -899,7 +899,8 @@ func autoLink(p *Parser, data []byte, offset int) (int, ast.Node) {
 	origData := data
 	data = data[offset-rewind:]
 
-	if !isSafeLink(data) {
+	safeURIs := append(valid.URIs, p.AutoLinkExtraSafeURIs...)
+	if !isSafeLink(data, safeURIs) {
 		return 0, nil
 	}
 
@@ -995,7 +996,7 @@ func isEndOfLink(char byte) bool {
 	return isSpace(char) || char == '<'
 }
 
-func isSafeLink(link []byte) bool {
+func isSafeLink(link []byte, validURIs [][]byte) bool {
 	nLink := len(link)
 	for _, path := range valid.Paths {
 		nPath := len(path)
@@ -1009,7 +1010,7 @@ func isSafeLink(link []byte) bool {
 		}
 	}
 
-	for _, prefix := range valid.URIs {
+	for _, prefix := range validURIs {
 		// TODO: handle unicode here
 		// case-insensitive prefix test
 		nPrefix := len(prefix)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -84,6 +84,9 @@ type Parser struct {
 	// the bottom will be used to fill in the link details.
 	ReferenceOverride ReferenceOverrideFunc
 
+	// AutoLinkExtraSafeURIs adds extra entries to the list of URIs, which auto linker considers as safe and allows them to be converted to markdown links.
+	AutoLinkExtraSafeURIs [][]byte
+
 	Opts Options
 
 	// after parsing, this is AST root of parsed markdown text


### PR DESCRIPTION
List of URI schemes is ever growing and instead of hard coding the values, the library should let its users extend the list with whatever values they want. It's only allowed to add to the list (of default values), because I consider the situation where someone doesn't want the default schemes auto-linked as unlikely.

Use of `append` at these particular places may have some impact on performance. I ran the benchmarks but as someone who's not experienced writing benchmarks, I can't be sure. I would appreciate someone's help.