### PR TITLE
Move shared functions in a common internal package

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -278,15 +278,11 @@ func appendLinkAttrs(attrs []string, flags Flags, link []byte) []string {
 	return append(attrs, attr)
 }
 
-func isMailto(link []byte) bool {
-	return bytes.HasPrefix(link, []byte("mailto:"))
-}
-
 func needSkipLink(flags Flags, dest []byte) bool {
 	if flags&SkipLinks != 0 {
 		return true
 	}
-	return flags&Safelink != 0 && !isSafeLink(dest) && !isMailto(dest)
+	return flags&Safelink != 0 && !isSafeLink(dest) && !utils.IsMailto(dest)
 }
 
 func appendLanguageAttr(attrs []string, info []byte) []string {

--- a/html/smartypants.go
+++ b/html/smartypants.go
@@ -2,6 +2,7 @@ package html
 
 import (
 	"bytes"
+	"github.com/gomarkdown/markdown/internal/utils"
 	"io"
 )
 
@@ -15,7 +16,7 @@ type SPRenderer struct {
 }
 
 func wordBoundary(c byte) bool {
-	return c == 0 || isSpace(c) || isPunctuation(c)
+	return c == 0 || utils.IsSpace(c) || utils.IsPunctuation(c)
 }
 
 func tolower(c byte) byte {
@@ -23,10 +24,6 @@ func tolower(c byte) byte {
 		return c - 'A' + 'a'
 	}
 	return c
-}
-
-func isdigit(c byte) bool {
-	return c >= '0' && c <= '9'
 }
 
 func smartQuoteHelper(out *bytes.Buffer, previousChar byte, nextChar byte, quote byte, isOpen *bool, addNBSP bool) bool {
@@ -39,46 +36,46 @@ func smartQuoteHelper(out *bytes.Buffer, previousChar byte, nextChar byte, quote
 	case previousChar == 0 && nextChar == 0:
 		// context is not any help here, so toggle
 		*isOpen = !*isOpen
-	case isSpace(previousChar) && nextChar == 0:
+	case utils.IsSpace(previousChar) && nextChar == 0:
 		// [ "] might be [ "<code>foo...]
 		*isOpen = true
-	case isPunctuation(previousChar) && nextChar == 0:
+	case utils.IsPunctuation(previousChar) && nextChar == 0:
 		// [!"] hmm... could be [Run!"] or [("<code>...]
 		*isOpen = false
 	case /* isnormal(previousChar) && */ nextChar == 0:
 		// [a"] is probably a close
 		*isOpen = false
-	case previousChar == 0 && isSpace(nextChar):
+	case previousChar == 0 && utils.IsSpace(nextChar):
 		// [" ] might be [...foo</code>" ]
 		*isOpen = false
-	case isSpace(previousChar) && isSpace(nextChar):
+	case utils.IsSpace(previousChar) && utils.IsSpace(nextChar):
 		// [ " ] context is not any help here, so toggle
 		*isOpen = !*isOpen
-	case isPunctuation(previousChar) && isSpace(nextChar):
+	case utils.IsPunctuation(previousChar) && utils.IsSpace(nextChar):
 		// [!" ] is probably a close
 		*isOpen = false
-	case /* isnormal(previousChar) && */ isSpace(nextChar):
+	case /* isnormal(previousChar) && */ utils.IsSpace(nextChar):
 		// [a" ] this is one of the easy cases
 		*isOpen = false
-	case previousChar == 0 && isPunctuation(nextChar):
+	case previousChar == 0 && utils.IsPunctuation(nextChar):
 		// ["!] hmm... could be ["$1.95] or [</code>"!...]
 		*isOpen = false
-	case isSpace(previousChar) && isPunctuation(nextChar):
+	case utils.IsSpace(previousChar) && utils.IsPunctuation(nextChar):
 		// [ "!] looks more like [ "$1.95]
 		*isOpen = true
-	case isPunctuation(previousChar) && isPunctuation(nextChar):
+	case utils.IsPunctuation(previousChar) && utils.IsPunctuation(nextChar):
 		// [!"!] context is not any help here, so toggle
 		*isOpen = !*isOpen
-	case /* isnormal(previousChar) && */ isPunctuation(nextChar):
+	case /* isnormal(previousChar) && */ utils.IsPunctuation(nextChar):
 		// [a"!] is probably a close
 		*isOpen = false
 	case previousChar == 0 /* && isnormal(nextChar) */ :
 		// ["a] is probably an open
 		*isOpen = true
-	case isSpace(previousChar) /* && isnormal(nextChar) */ :
+	case utils.IsSpace(previousChar) /* && isnormal(nextChar) */ :
 		// [ "a] this is one of the easy cases
 		*isOpen = true
-	case isPunctuation(previousChar) /* && isnormal(nextChar) */ :
+	case utils.IsPunctuation(previousChar) /* && isnormal(nextChar) */ :
 		// [!"a] is probably an open
 		*isOpen = true
 	default:
@@ -272,7 +269,7 @@ func (r *SPRenderer) smartNumberGeneric(out *bytes.Buffer, previousChar byte, te
 		// note: check for regular slash (/) or fraction slash (⁄, 0x2044, or 0xe2 81 84 in utf-8)
 		//       and avoid changing dates like 1/23/2005 into fractions.
 		numEnd := 0
-		for len(text) > numEnd && isdigit(text[numEnd]) {
+		for len(text) > numEnd && utils.IsDigit(text[numEnd]) {
 			numEnd++
 		}
 		if numEnd == 0 {
@@ -287,7 +284,7 @@ func (r *SPRenderer) smartNumberGeneric(out *bytes.Buffer, previousChar byte, te
 			return 0
 		}
 		denEnd := denStart
-		for len(text) > denEnd && isdigit(text[denEnd]) {
+		for len(text) > denEnd && utils.IsDigit(text[denEnd]) {
 			denEnd++
 		}
 		if denEnd == denStart {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,6 +1,9 @@
 package utils
 
-import "github.com/gomarkdown/markdown/ast"
+import (
+	"bytes"
+	"github.com/gomarkdown/markdown/ast"
+)
 
 // IsAlnum returns true if c is a digit or letter
 // TODO: check when this is looking for ASCII alnum and when it should use unicode
@@ -31,6 +34,11 @@ func IsPunctuation(c byte) bool {
 		}
 	}
 	return false
+}
+
+// IsMailto returns true if link starts with "mailto:".
+func IsMailto(link []byte) bool {
+	return bytes.HasPrefix(link, []byte("mailto:"))
 }
 
 func IsListItem(node ast.Node) bool {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,56 @@
+package utils
+
+import "github.com/gomarkdown/markdown/ast"
+
+// IsAlnum returns true if c is a digit or letter
+// TODO: check when this is looking for ASCII alnum and when it should use unicode
+func IsAlnum(c byte) bool {
+	return IsDigit(c) || IsLetter(c)
+}
+
+// IsDigit returns true if c is a digit
+func IsDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+// IsSpace returns true if c is a white-space charactr
+func IsSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
+}
+
+// IsLetter returns true if c is ascii letter
+func IsLetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// IsPunctuation returns true if c is a punctuation symbol.
+func IsPunctuation(c byte) bool {
+	for _, r := range []byte("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~") {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+func IsListItem(node ast.Node) bool {
+	_, ok := node.(*ast.ListItem)
+	return ok
+}
+
+func IsListItemTerm(node ast.Node) bool {
+	data, ok := node.(*ast.ListItem)
+	return ok && data.ListFlags&ast.ListTypeTerm != 0
+}
+
+func IsList(node ast.Node) bool {
+	_, ok := node.(*ast.List)
+	return ok
+}
+
+func IsListTight(node ast.Node) bool {
+	if list, ok := node.(*ast.List); ok {
+		return list.Tight
+	}
+	return false
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import "testing"
+
+func TestIsAlnum(t *testing.T) {
+	for _, c := range []byte{'4', 'z', 'A', '0', '9'} {
+		if !IsAlnum(c) {
+			t.Errorf("'%c' not recognized as an alphanumeric symbol", c)
+		}
+	}
+
+	for _, c := range []byte{'%', '_', '-', '@', '!'} {
+		if IsAlnum(c) {
+			t.Errorf("'%c' recognized as an alphanumeric symbol", c)
+		}
+	}
+}
+
+func TestIsDigit(t *testing.T) {
+	for _, c := range []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'} {
+		if !IsDigit(c) {
+			t.Errorf("'%c' not recognized as a numeric symbol", c)
+		}
+	}
+
+	for _, c := range []byte{'%', '_', '-', '@', '!', 'z', 'A', 'x'} {
+		if IsDigit(c) {
+			t.Errorf("'%c' recognized as a numeric symbol", c)
+		}
+	}
+}
+
+func TestIsLetter(t *testing.T) {
+	for _, c := range []byte{'A', 'b', 'C', 'd', 'E', 'f', 'G', 'Z', 'X', 'Y'} {
+		if !IsLetter(c) {
+			t.Errorf("'%c' not recognized as a letter", c)
+		}
+	}
+
+	for _, c := range []byte{'%', '_', '-', '@', '!', '0', '1', '3'} {
+		if IsLetter(c) {
+			t.Errorf("'%c' recognized as a letter", c)
+		}
+	}
+}
+
+func TestIsMailto(t *testing.T) {
+	if b := []byte("mailto:doe@example.com"); !IsMailto(b) {
+		t.Errorf("'%s' is not mailto:", b)
+	}
+
+	if b := []byte("http://www.example.com"); IsMailto(b) {
+		t.Errorf("'%s' is not mailto:", b)
+	}
+}

--- a/parser/block.go
+++ b/parser/block.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"github.com/gomarkdown/markdown/internal/utils"
 	"html"
 	"regexp"
 	"strconv"
@@ -909,18 +910,18 @@ func syntaxRange(data []byte, iout *int) (int, int) {
 
 		// strip all whitespace at the beginning and the end
 		// of the {} block
-		for syn > 0 && isSpace(data[syntaxStart]) {
+		for syn > 0 && utils.IsSpace(data[syntaxStart]) {
 			syntaxStart++
 			syn--
 		}
 
-		for syn > 0 && isSpace(data[syntaxStart+syn-1]) {
+		for syn > 0 && utils.IsSpace(data[syntaxStart+syn-1]) {
 			syn--
 		}
 
 		i++
 	} else {
-		for i < n && !isSpace(data[i]) {
+		for i < n && !utils.IsSpace(data[i]) {
 			syn++
 			i++
 		}
@@ -1767,7 +1768,7 @@ func skipUntilChar(data []byte, i int, c byte) int {
 
 func skipAlnum(data []byte, i int) int {
 	n := len(data)
-	for i < n && isAlnum(data[i]) {
+	for i < n && utils.IsAlnum(data[i]) {
 		i++
 	}
 	return i
@@ -1775,7 +1776,7 @@ func skipAlnum(data []byte, i int) int {
 
 func skipSpace(data []byte, i int) int {
 	n := len(data)
-	for i < n && isSpace(data[i]) {
+	for i < n && utils.IsSpace(data[i]) {
 		i++
 	}
 	return i

--- a/parser/caption.go
+++ b/parser/caption.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"github.com/gomarkdown/markdown/internal/utils"
 )
 
 // caption checks for a caption, it returns the caption data and a potential "headingID".
@@ -58,7 +59,7 @@ func captionID(data []byte) (string, int) {
 	}
 	// remains must be whitespace.
 	for l := k + 1; l < end; l++ {
-		if !isSpace(data[l]) {
+		if !utils.IsSpace(data[l]) {
 			return "", 0
 		}
 	}

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -676,10 +676,12 @@ func (p *Parser) inlineHTMLComment(data []byte) int {
 }
 
 func stripMailto(link []byte) []byte {
-	if bytes.HasPrefix(link, []byte("mailto://")) {
-		return link[9:]
-	} else if bytes.HasPrefix(link, []byte("mailto:")) {
-		return link[7:]
+	if utils.IsMailto(link) {
+		l := link[7:]
+		if bytes.HasPrefix(l, []byte("//")) {
+			return l[2:]
+		}
+		return l
 	} else {
 		return link
 	}

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -2,11 +2,12 @@ package parser
 
 import (
 	"bytes"
+	"github.com/gomarkdown/markdown/internal/utils"
+	"github.com/gomarkdown/markdown/internal/valid"
 	"regexp"
 	"strconv"
 
 	"github.com/gomarkdown/markdown/ast"
-	"github.com/gomarkdown/markdown/internal/valid"
 )
 
 // Parsing of inline elements
@@ -69,7 +70,7 @@ func emphasis(p *Parser, data []byte, offset int) (int, ast.Node) {
 	if n > 2 && data[1] != c {
 		// whitespace cannot follow an opening emphasis;
 		// strikethrough only takes two characters '~~'
-		if isSpace(data[1]) {
+		if utils.IsSpace(data[1]) {
 			return 0, nil
 		}
 		if p.extensions&SuperSubscript != 0 && c == '~' {
@@ -81,7 +82,7 @@ func emphasis(p *Parser, data []byte, offset int) (int, ast.Node) {
 			}
 			ret++ // we started with data[1:] above.
 			for i := 1; i < ret; i++ {
-				if isSpace(data[i]) && !isEscape(data, i) {
+				if utils.IsSpace(data[i]) && !isEscape(data, i) {
 					return 0, nil
 				}
 			}
@@ -98,7 +99,7 @@ func emphasis(p *Parser, data []byte, offset int) (int, ast.Node) {
 	}
 
 	if n > 3 && data[1] == c && data[2] != c {
-		if isSpace(data[2]) {
+		if utils.IsSpace(data[2]) {
 			return 0, nil
 		}
 		ret, node := helperDoubleEmphasis(p, data[2:], c)
@@ -110,7 +111,7 @@ func emphasis(p *Parser, data []byte, offset int) (int, ast.Node) {
 	}
 
 	if n > 4 && data[1] == c && data[2] == c && data[3] != c {
-		if c == '~' || isSpace(data[3]) {
+		if c == '~' || utils.IsSpace(data[3]) {
 			return 0, nil
 		}
 		ret, node := helperTripleEmphasis(p, data, 3, c)
@@ -156,7 +157,7 @@ func codeSpan(p *Parser, data []byte, offset int) (int, ast.Node) {
 		if data[j] == '\n' {
 			break
 		}
-		if !isSpace(data[j]) {
+		if !utils.IsSpace(data[j]) {
 			hasCharsAfterDelimiter = true
 		}
 	}
@@ -256,7 +257,7 @@ func maybeInlineFootnoteOrSuper(p *Parser, data []byte, offset int) (int, ast.No
 			return 0, nil
 		}
 		for i := offset; i < offset+ret; i++ {
-			if isSpace(data[i]) && !isEscape(data, i) {
+			if utils.IsSpace(data[i]) && !isEscape(data, i) {
 				return 0, nil
 			}
 		}
@@ -421,7 +422,7 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 
 			// skip whitespace after title
 			titleE = i - 1
-			for titleE > titleB && isSpace(data[titleE]) {
+			for titleE > titleB && utils.IsSpace(data[titleE]) {
 				titleE--
 			}
 
@@ -433,7 +434,7 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 		}
 
 		// remove whitespace at the end of the link
-		for linkE > linkB && isSpace(data[linkE-1]) {
+		for linkE > linkB && utils.IsSpace(data[linkE-1]) {
 			linkE--
 		}
 
@@ -889,7 +890,7 @@ func autoLink(p *Parser, data []byte, offset int) (int, ast.Node) {
 
 	// scan backward for a word boundary
 	rewind := 0
-	for offset-rewind > 0 && rewind <= 7 && isLetter(data[offset-rewind-1]) {
+	for offset-rewind > 0 && rewind <= 7 && utils.IsLetter(data[offset-rewind-1]) {
 		rewind++
 	}
 	if rewind > 6 { // longest supported protocol is "mailto" which has 6 letters
@@ -992,7 +993,7 @@ func autoLink(p *Parser, data []byte, offset int) (int, ast.Node) {
 }
 
 func isEndOfLink(char byte) bool {
-	return isSpace(char) || char == '<'
+	return utils.IsSpace(char) || char == '<'
 }
 
 func isSafeLink(link []byte) bool {
@@ -1003,7 +1004,7 @@ func isSafeLink(link []byte) bool {
 		if nLink >= nPath && bytes.Equal(linkPrefix, path) {
 			if nLink == nPath {
 				return true
-			} else if isAlnum(link[nPath]) {
+			} else if utils.IsAlnum(link[nPath]) {
 				return true
 			}
 		}
@@ -1015,7 +1016,7 @@ func isSafeLink(link []byte) bool {
 		nPrefix := len(prefix)
 		if nLink > nPrefix {
 			linkPrefix := bytes.ToLower(link[:nPrefix])
-			if bytes.Equal(linkPrefix, prefix) && isAlnum(link[nPrefix]) {
+			if bytes.Equal(linkPrefix, prefix) && utils.IsAlnum(link[nPrefix]) {
 				return true
 			}
 		}
@@ -1043,7 +1044,7 @@ func tagLength(data []byte) (autolink autolinkType, end int) {
 		i = 1
 	}
 
-	if !isAlnum(data[i]) {
+	if !utils.IsAlnum(data[i]) {
 		return notAutolink, 0
 	}
 
@@ -1051,7 +1052,7 @@ func tagLength(data []byte) (autolink autolinkType, end int) {
 	autolink = notAutolink
 
 	// try to find the beginning of an URI
-	for i < len(data) && (isAlnum(data[i]) || data[i] == '.' || data[i] == '+' || data[i] == '-') {
+	for i < len(data) && (utils.IsAlnum(data[i]) || data[i] == '.' || data[i] == '+' || data[i] == '-') {
 		i++
 	}
 
@@ -1076,7 +1077,7 @@ func tagLength(data []byte) (autolink autolinkType, end int) {
 		for i < len(data) {
 			if data[i] == '\\' {
 				i += 2
-			} else if data[i] == '>' || data[i] == '\'' || data[i] == '"' || isSpace(data[i]) {
+			} else if data[i] == '>' || data[i] == '\'' || data[i] == '"' || utils.IsSpace(data[i]) {
 				break
 			} else {
 				i++
@@ -1108,7 +1109,7 @@ func isMailtoAutoLink(data []byte) int {
 
 	// address is assumed to be: [-@._a-zA-Z0-9]+ with exactly one '@'
 	for i, c := range data {
-		if isAlnum(c) {
+		if utils.IsAlnum(c) {
 			continue
 		}
 
@@ -1229,10 +1230,10 @@ func helperEmphasis(p *Parser, data []byte, c byte) (int, ast.Node) {
 			continue
 		}
 
-		if data[i] == c && !isSpace(data[i-1]) {
+		if data[i] == c && !utils.IsSpace(data[i-1]) {
 
 			if p.extensions&NoIntraEmphasis != 0 {
-				if !(i+1 == len(data) || isSpace(data[i+1]) || isPunctuation(data[i+1])) {
+				if !(i+1 == len(data) || utils.IsSpace(data[i+1]) || utils.IsPunctuation(data[i+1])) {
 					continue
 				}
 			}
@@ -1256,7 +1257,7 @@ func helperDoubleEmphasis(p *Parser, data []byte, c byte) (int, ast.Node) {
 		}
 		i += length
 
-		if i+1 < len(data) && data[i] == c && data[i+1] == c && i > 0 && !isSpace(data[i-1]) {
+		if i+1 < len(data) && data[i] == c && data[i+1] == c && i > 0 && !utils.IsSpace(data[i-1]) {
 			var node ast.Node = &ast.Strong{}
 			if c == '~' {
 				node = &ast.Del{}
@@ -1282,7 +1283,7 @@ func helperTripleEmphasis(p *Parser, data []byte, offset int, c byte) (int, ast.
 		i += length
 
 		// skip whitespace preceded symbols
-		if data[i] != c || isSpace(data[i-1]) {
+		if data[i] != c || utils.IsSpace(data[i-1]) {
 			continue
 		}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,6 +6,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"github.com/gomarkdown/markdown/internal/utils"
 	"strconv"
 	"strings"
 
@@ -217,9 +218,9 @@ func (p *Parser) addChild(node ast.Node) ast.Node {
 func canNodeContain(n ast.Node, v ast.Node) bool {
 	switch n.(type) {
 	case *ast.List:
-		return isListItem(v)
+		return utils.IsListItem(v)
 	case *ast.Document, *ast.BlockQuote, *ast.Aside, *ast.ListItem, *ast.CaptionFigure:
-		return !isListItem(v)
+		return !utils.IsListItem(v)
 	case *ast.Table:
 		switch v.(type) {
 		case *ast.TableHeader, *ast.TableBody, *ast.TableFooter:
@@ -690,32 +691,6 @@ gatherLines:
 	return
 }
 
-// isPunctuation returns true if c is a punctuation symbol.
-func isPunctuation(c byte) bool {
-	for _, r := range []byte("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~") {
-		if c == r {
-			return true
-		}
-	}
-	return false
-}
-
-// isSpace returns true if c is a white-space charactr
-func isSpace(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
-}
-
-// isLetter returns true if c is ascii letter
-func isLetter(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-}
-
-// isAlnum returns true if c is a digit or letter
-// TODO: check when this is looking for ASCII alnum and when it should use unicode
-func isAlnum(c byte) bool {
-	return (c >= '0' && c <= '9') || isLetter(c)
-}
-
 // TODO: this is not used
 // Replace tab characters with spaces, aligning to the next TAB_SIZE column.
 // always ends output with a newline
@@ -806,7 +781,7 @@ func slugify(in []byte) []byte {
 	sym := false
 
 	for _, ch := range in {
-		if isAlnum(ch) {
+		if utils.IsAlnum(ch) {
 			sym = false
 			out = append(out, ch)
 		} else if sym {
@@ -829,9 +804,4 @@ func slugify(in []byte) []byte {
 		}
 	}
 	return out[a : b+1]
-}
-
-func isListItem(d ast.Node) bool {
-	_, ok := d.(*ast.ListItem)
-	return ok
 }

--- a/parser/ref.go
+++ b/parser/ref.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"github.com/gomarkdown/markdown/internal/utils"
 
 	"github.com/gomarkdown/markdown/ast"
 )
@@ -25,7 +26,7 @@ func maybeShortRefOrIndex(p *Parser, data []byte, offset int) (int, ast.Node) {
 			switch {
 			case c == ')':
 				break Loop
-			case !isAlnum(c):
+			case !utils.IsAlnum(c):
 				if c == '_' || c == '-' || c == ':' {
 					i++
 					continue


### PR DESCRIPTION
This series of commits moves the same unexported functions defined across different packages in `internal/utils` and adds unit tests. I admit that the naming is lazy and am willing to rename if someone comes with a better name.

I noticed the imports are also affected, which I reckon is due to me using a different tool for auto-formatting (gofmt).