### PR TITLE
Add IsSafeURLOverride

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -556,6 +556,12 @@ func TestSafeInlineLink(t *testing.T) {
 		"[foo](mailto:bar/)\n",
 		"<p><a href=\"mailto:bar/\">foo</a></p>\n",
 
+		"[foo](monero:4AfUP827TeRZ1cck3tZThgZbRCEwBrpcJTkA1LCiyFVuMH4b5y59bKMZHGb9y58K3gSjWDCBsB4RkGsGDhsmMG5R2qmbLeW)\n",
+		"<p><a href=\"monero:4AfUP827TeRZ1cck3tZThgZbRCEwBrpcJTkA1LCiyFVuMH4b5y59bKMZHGb9y58K3gSjWDCBsB4RkGsGDhsmMG5R2qmbLeW\">foo</a></p>\n",
+
+		"[foo](bitcoin:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh)\n",
+		"<p><a href=\"bitcoin:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh\">foo</a></p>\n",
+
 		// Not considered safe
 		"[foo](baz://bar/)\n",
 		"<p><tt>foo</tt></p>\n",

--- a/internal/valid/valid.go
+++ b/internal/valid/valid.go
@@ -1,5 +1,9 @@
 package valid
 
+import (
+	"bytes"
+)
+
 var URIs = [][]byte{
 	[]byte("http://"),
 	[]byte("https://"),
@@ -11,4 +15,45 @@ var Paths = [][]byte{
 	[]byte("/"),
 	[]byte("./"),
 	[]byte("../"),
+}
+
+// TODO: documentation
+func IsSafeURL(url []byte) bool {
+	nLink := len(url)
+	for _, path := range Paths {
+		nPath := len(path)
+		linkPrefix := url[:nPath]
+		if nLink >= nPath && bytes.Equal(linkPrefix, path) {
+			if nLink == nPath {
+				return true
+			} else if isAlnum(url[nPath]) {
+				return true
+			}
+		}
+	}
+
+	for _, prefix := range URIs {
+		// TODO: handle unicode here
+		// case-insensitive prefix test
+		nPrefix := len(prefix)
+		if nLink > nPrefix {
+			linkPrefix := bytes.ToLower(url[:nPrefix])
+			if bytes.Equal(linkPrefix, prefix) && isAlnum(url[nPrefix]) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isAlnum returns true if c is a digit or letter
+// TODO: check when this is looking for ASCII alnum and when it should use unicode
+func isAlnum(c byte) bool {
+	return (c >= '0' && c <= '9') || isLetter(c)
+}
+
+// isLetter returns true if c is ascii letter
+func isLetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -899,7 +899,11 @@ func autoLink(p *Parser, data []byte, offset int) (int, ast.Node) {
 	origData := data
 	data = data[offset-rewind:]
 
-	if !isSafeLink(data) {
+	isSafeURL := p.IsSafeURLOverride
+	if isSafeURL == nil {
+		isSafeURL = valid.IsSafeURL
+	}
+	if !isSafeURL(data) {
 		return 0, nil
 	}
 
@@ -993,35 +997,6 @@ func autoLink(p *Parser, data []byte, offset int) (int, ast.Node) {
 
 func isEndOfLink(char byte) bool {
 	return isSpace(char) || char == '<'
-}
-
-func isSafeLink(link []byte) bool {
-	nLink := len(link)
-	for _, path := range valid.Paths {
-		nPath := len(path)
-		linkPrefix := link[:nPath]
-		if nLink >= nPath && bytes.Equal(linkPrefix, path) {
-			if nLink == nPath {
-				return true
-			} else if isAlnum(link[nPath]) {
-				return true
-			}
-		}
-	}
-
-	for _, prefix := range valid.URIs {
-		// TODO: handle unicode here
-		// case-insensitive prefix test
-		nPrefix := len(prefix)
-		if nLink > nPrefix {
-			linkPrefix := bytes.ToLower(link[:nPrefix])
-			if bytes.Equal(linkPrefix, prefix) && isAlnum(link[nPrefix]) {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // return the length of the given tag, or 0 is it's not valid

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -84,6 +84,9 @@ type Parser struct {
 	// the bottom will be used to fill in the link details.
 	ReferenceOverride ReferenceOverrideFunc
 
+	// TODO: documentation
+	IsSafeURLOverride func(url []byte) bool
+
 	Opts Options
 
 	// after parsing, this is AST root of parsed markdown text


### PR DESCRIPTION
If set, the hook overrides the default `IsSafeURL` and allows users of the library to decide which URIs are safe to keep. This asked for some refactoring which I made into separate commits. I think the PR is quite big and thought it would be best to review it as two separate PRs. However, I didn't communicate my intentions and this was met with [misunderstanding](https://github.com/gomarkdown/markdown/pull/251). This time around I'm submitting the branch as is. I have left some TODOs which I will take care once this gets some eyeballs.