### PR TITLE
Allow "empty links"

### DIFF
--- a/parser/inline.go
+++ b/parser/inline.go
@@ -601,7 +601,8 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 		}
 
 		// links need something to click on and somewhere to go
-		if len(uLink) == 0 || (t == linkNormal && txtE <= 1) {
+		// [](http://bla) is legal in CommonMark, so allow txtE <=1 for linkNormal
+		if len(uLink) == 0 {
 			return 0, nil
 		}
 	}

--- a/testdata/Links, inline style.html
+++ b/testdata/Links, inline style.html
@@ -30,4 +30,6 @@
 
 <p><a href="-" title="title saying meh ¯\_(ツ)_/¯">hyphen and title</a>.</p>
 
+<p><a href="empty"></a>.</p>
+
 <p>[Empty]().</p>

--- a/testdata/Links, inline style.text
+++ b/testdata/Links, inline style.text
@@ -30,4 +30,6 @@ Just a [URL](/url/).
 
 [hyphen and title](- 'title saying meh ¯\_(ツ)_/¯').
 
+[](empty).
+
 [Empty]().


### PR DESCRIPTION
[](http://bla) is considered a link in CommonMark and GFM, support this
here too. It does not generate something a user can click so it's a bit
questionable.

Updated tests as well.

Signed-off-by: Miek Gieben <miek@miek.nl>
