### PR TITLE
Support [foo]() syntax

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -217,6 +217,11 @@ func NewRenderer(opts RendererOptions) *Renderer {
 }
 
 func isRelativeLink(link []byte) (yes bool) {
+	// empty links considerd relative
+	if len(link) == 0 {
+		return true
+	}
+
 	// a tag begin with '#'
 	if link[0] == '#' {
 		return true
@@ -246,6 +251,9 @@ func isRelativeLink(link []byte) (yes bool) {
 }
 
 func (r *Renderer) addAbsPrefix(link []byte) []byte {
+	if len(link) == 0 {
+		return link
+	}
 	if r.opts.AbsolutePrefix != "" && isRelativeLink(link) && link[0] != '.' {
 		newDest := r.opts.AbsolutePrefix
 		if link[0] != '/' {

--- a/inline_test.go
+++ b/inline_test.go
@@ -341,7 +341,7 @@ func TestInlineLink(t *testing.T) {
 		"<p><a href=\"/bar/ title with no quotes\">foo with a title</a></p>\n",
 
 		"[foo]()\n",
-		"<p>[foo]()</p>\n",
+		"<p><a href=\"\">foo</a></p>\n",
 
 		"![foo](/bar/)\n",
 		"<p><img src=\"/bar/\" alt=\"foo\" /></p>\n",
@@ -365,7 +365,7 @@ func TestInlineLink(t *testing.T) {
 		"<p><a href=\"url\">link</a></p>\n",
 
 		"![foo]()\n",
-		"<p>![foo]()</p>\n",
+		"<p><img src=\"\" alt=\"foo\" /></p>\n",
 
 		"[a link]\t(/with_a_tab/)\n",
 		"<p><a href=\"/with_a_tab/\">a link</a></p>\n",

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -602,9 +602,7 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 
 		// links need something to click on and somewhere to go
 		// [](http://bla) is legal in CommonMark, so allow txtE <=1 for linkNormal
-		if len(uLink) == 0 {
-			return 0, nil
-		}
+		// [bla]() is also legal in CommonMark, so allow empty uLink
 	}
 
 	// call the relevant rendering function

--- a/testdata/Links, inline style.html
+++ b/testdata/Links, inline style.html
@@ -32,4 +32,4 @@
 
 <p><a href="empty"></a>.</p>
 
-<p>[Empty]().</p>
+<p><a href="">Empty</a>.</p>


### PR DESCRIPTION
See 558d915, this supports the reverse as well: `[foo]()` is turned into
a empty ahref - also affects the img rendering. Checked with
https://commonmark.org/help/tutorial/07-links.html what CommonMark
thinks of this and it says 'OK'

This indeed trickers a crash when accessing uLink[0], fixes that and
updated the tests.

Closes #257

Signed-off-by: Miek Gieben <miek@miek.nl>
