### PR TITLE
Allow suffix for cross references

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -272,6 +272,7 @@ type CrossReference struct {
 	Container
 
 	Destination []byte // Destination is where the reference points to
+	Suffix      []byte // Potential citation suffix, i.e. (#myid, text)
 }
 
 // Citation is a citation node.

--- a/parser/ref.go
+++ b/parser/ref.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gomarkdown/markdown/ast"
 )
 
-// parse '(#r)', where r does not contain spaces. Or.
-// (!item) (!item, subitem), for an index, (!!item) signals primary.
+// parse '(#r, text)', where r does not contain spaces, but text may (similar to a citation). Or. (!item) (!item,
+// subitem), for an index, (!!item) signals primary.
 func maybeShortRefOrIndex(p *Parser, data []byte, offset int) (int, ast.Node) {
 	if len(data[offset:]) < 4 {
 		return 0, nil
@@ -26,7 +26,7 @@ func maybeShortRefOrIndex(p *Parser, data []byte, offset int) (int, ast.Node) {
 			case c == ')':
 				break Loop
 			case !IsAlnum(c):
-				if c == '_' || c == '-' || c == ':' {
+				if c == '_' || c == '-' || c == ':' || c == ' ' || c == ',' {
 					i++
 					continue
 				}
@@ -45,6 +45,21 @@ func maybeShortRefOrIndex(p *Parser, data []byte, offset int) (int, ast.Node) {
 		id := data[2:i]
 		node := &ast.CrossReference{}
 		node.Destination = id
+		if c := bytes.Index(id, []byte(",")); c > 0 {
+			idpart := id[:c]
+			suff := id[c+1:]
+			suff = bytes.TrimSpace(suff)
+			node.Destination = idpart
+			node.Suffix = suff
+		}
+		if bytes.Index(node.Destination, []byte(" ")) > 0 {
+			// no spaces allowed in id
+			return 0, nil
+		}
+		if bytes.Index(node.Destination, []byte(",")) > 0 {
+			// nor comma
+			return 0, nil
+		}
 
 		return i + 1, node
 

--- a/parser/ref_test.go
+++ b/parser/ref_test.go
@@ -19,14 +19,18 @@ func TestCrossReference(t *testing.T) {
 			data: []byte("(#yes)"),
 			r:    &ast.CrossReference{Destination: []byte("yes")},
 		},
-		// ok
 		{
 			data: []byte("(#y:es)"),
 			r:    &ast.CrossReference{Destination: []byte("y:es")},
 		},
+		{
+			data: []byte("(#id, random text)"),
+			r:    &ast.CrossReference{Destination: []byte("id"), Suffix: []byte("random text")},
+		},
 		// fails
 		{data: []byte("(#y es)"), r: nil, fail: true},
 		{data: []byte("(#yes"), r: nil, fail: true},
+		{data: []byte("(#y es, random text"), r: nil, fail: true},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
See issue #223 for initial discussion. This is implemented in this PR,
added tests in ref_test.go.

Only issue is that: `(#y,es)` is now a valid reference, with the ID
being set to "y" - which may be surprising? Potentially this can be
hidden behind (another) extension?

The XMLv3 standard allows a 'format' attribute, so this is not going
away and provides a neat way to be able to set that attribute.

Signed-off-by: Miek Gieben <miek@miek.nl>
