### PR TITLE
Allow setting empty children on Leaf node

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -157,9 +157,13 @@ func (l *Leaf) GetChildren() []Node {
 	return nil
 }
 
-// SetChildren will panic becuase Leaf cannot have children
+// SetChildren will panic if trying to set non-empty children
+// because Leaf cannot have children
 func (l *Leaf) SetChildren(newChildren []Node) {
-	panic("leaf node cannot have children")
+	if len(newChildren) != 0 {
+		panic("leaf node cannot have children")
+	}
+
 }
 
 // Document represents markdown document node, a root of ast

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -1,0 +1,85 @@
+package ast
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestContainerCanHaveChildren(t *testing.T) {
+	parent := &Container{}
+	child := &Leaf{}
+
+	if len(parent.GetChildren()) != 0 {
+		t.Error("Parent did not start out without children")
+	}
+
+	newChildren := []Node{child}
+	parent.SetChildren(newChildren)
+	child.Parent = parent
+
+	if !reflect.DeepEqual(parent.GetChildren(), newChildren) {
+		t.Error("Failed to set children")
+	}
+}
+
+func TestLeafCannotHaveChildren(t *testing.T) {
+	parent := &Leaf{}
+	child := &Leaf{}
+
+	newChildren := []Node{child}
+
+	// Expect that SetChildren panics
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Leaf.SetChildren did not panic but was expected to")
+		}
+	}()
+
+	parent.SetChildren(newChildren)
+	child.Parent = parent
+}
+
+func TestLeafCanSetEmptyChildren(t *testing.T) {
+	parent := &Leaf{}
+
+	parent.SetChildren(nil)
+	parent.SetChildren([]Node{})
+}
+
+func TestRemoveLeaveFromTree(t *testing.T) {
+	// Create a tree to remove nodes from:
+	/*
+	      grandparent
+	           |
+	         parent
+	        /      \
+	 toBeRemoved  sibling
+	*/
+
+	grandparent := &Container{}
+	parent := &Container{}
+	toBeRemoved := &Leaf{}
+	sibling := &Leaf{}
+
+	grandparent.SetChildren([]Node{parent})
+	parent.Parent = grandparent
+
+	parent.SetChildren(([]Node{toBeRemoved, sibling}))
+	toBeRemoved.Parent = parent
+	sibling.Parent = parent
+
+	RemoveFromTree(toBeRemoved)
+
+	if !reflect.DeepEqual(grandparent.GetChildren(), []Node{parent}) {
+		t.Error("Unexpectedly modified children of grandparent when removing grandchild")
+	}
+
+	if !reflect.DeepEqual(parent.GetChildren(), []Node{sibling}) {
+		t.Errorf("Unexpected modification of removed node's siblings: %v", parent.GetChildren())
+	}
+
+	// The parent reference of the removed node is left intact
+	if toBeRemoved.Parent != parent {
+		t.Errorf("Unexpectedly modified parent of removed node to: %v", toBeRemoved.Parent)
+	}
+}


### PR DESCRIPTION
...which allows a Leaf to be used with RemoveFromTree, see #262

Rather than changing `RemoveFromTree` to check for leaves, it made more sense to me to allow setting "empty" children on a leaf.