### PR TITLE
Fix: escape `$`

### DIFF
--- a/parser/inline.go
+++ b/parser/inline.go
@@ -736,7 +736,7 @@ func leftAngle(p *Parser, data []byte, offset int) (int, ast.Node) {
 }
 
 // '\\' backslash escape
-var escapeChars = []byte("\\`*_{}[]()#+-.!:|&<>~^")
+var escapeChars = []byte("\\`*_{}[]()#+-.!:|&<>~^$")
 
 func escape(p *Parser, data []byte, offset int) (int, ast.Node) {
 	data = data[offset:]

--- a/testdata/Backslash escapes.html
+++ b/testdata/Backslash escapes.html
@@ -34,6 +34,8 @@
 
 <p>Tilde: ~</p>
 
+<p>Dollar: $</p>
+
 <p>These should not, because they occur within a code block:</p>
 
 <pre><code>Backslash: \\
@@ -69,6 +71,8 @@ Plus: \+
 Minus: \-
 
 Tilde: \~
+
+Dollar: \$
 </code></pre>
 
 <p>Nor should these, which occur in code spans:</p>
@@ -106,6 +110,8 @@ Tilde: \~
 <p>Minus: <code>\-</code></p>
 
 <p>Tilde: <code>\~</code></p>
+
+<p>Dollar: <code>\$</code></p>
 
 <p>These should get escaped, even though they're matching pairs for
 other Markdown constructs:</p>

--- a/testdata/Backslash escapes.text
+++ b/testdata/Backslash escapes.text
@@ -34,7 +34,7 @@ Minus: \-
 
 Tilde: \~
 
-
+Dollar: \$
 
 These should not, because they occur within a code block:
 
@@ -72,6 +72,8 @@ These should not, because they occur within a code block:
 
 	Tilde: \~
 
+	Dollar: \$
+
 
 Nor should these, which occur in code spans:
 
@@ -108,6 +110,8 @@ Plus: `\+`
 Minus: `\-`
 
 Tilde: `\~`
+
+Dollar: `\$`
 
 
 These should get escaped, even though they're matching pairs for

--- a/testdata/Markdown Documentation - Syntax.html
+++ b/testdata/Markdown Documentation - Syntax.html
@@ -943,4 +943,5 @@ _   underscore
 -	minus sign (hyphen)
 .   dot
 !   exclamation mark
+$   dollar sign
 </code></pre>

--- a/testdata/Markdown Documentation - Syntax.text
+++ b/testdata/Markdown Documentation - Syntax.text
@@ -885,4 +885,4 @@ Markdown provides backslash escapes for the following characters:
 	-	minus sign (hyphen)
     .   dot
     !   exclamation mark
-
+    $   dollar sign


### PR DESCRIPTION
Closes #282

As suggested by @alexwennerberg, the fix is a simple 1 line change, adding the `$` to the slice of backslash escape-able characters.

The `\$` sequence was also added to the testdata.