### PR TITLE
Fix: respect DisableTags in OutTag func

### DIFF
--- a/html/renderer.go
+++ b/html/renderer.go
@@ -320,12 +320,16 @@ func appendLanguageAttr(attrs []string, info []byte) []string {
 }
 
 func (r *Renderer) OutTag(w io.Writer, name string, attrs []string) {
+	r.lastOutputLen = 1
 	s := name
 	if len(attrs) > 0 {
 		s += " " + strings.Join(attrs, " ")
 	}
-	io.WriteString(w, s+">")
-	r.lastOutputLen = 1
+	s = s + ">"
+	if r.DisableTags > 0 {
+		s = htmlTagRe.ReplaceAllString(s, "")
+	}
+	io.WriteString(w, s)
 }
 
 func FootnoteRef(prefix string, node *ast.Link) string {


### PR DESCRIPTION
## Explanation of the issue
I was checking how `DisableTags` works and I think intention of the autor was to disable HTML tags completely.
However at the moment when this field was set, only closing tags were removed. 


### Reproduction 
I added
```go
renderer.DisableTags = 1
```
after line https://github.com/gomarkdown/markdown/blob/master/cmd/printast/main.go#L56
and copied content of the `README.md` into `example.md`

(these are first few lines of `README.md`)
```
 markdown git:(master) ✗ go run ./cmd/printast -to-html example.md
HTML of file 'example.md':
<h1>Markdown Parser and HTML Renderer for Go

<a href="https://pkg.go.dev/github.com/gomarkdown/markdown">pkg.go.dev

Package github.com/gomarkdown/markdown is a Go library for parsing Markdown text and rendering as HTML.
```

after my changes it seems to work correctly

```
markdown git:(fix/disable-opening-tags) ✗ go run ./cmd/printast -to-html example.md              
HTML of file 'example.md':
Markdown Parser and HTML Renderer for Go

pkg.go.dev

Package github.com/gomarkdown/markdown is a Go library for parsing Markdown text and rendering as HTML.
```

(I have tested this on entire `README.md` content, here for readability I only included partial sample).

## Motivations

I'm proposing this fix for 2 reasons:
- I think this option was supposed to disable all HTML tags
- this change would allow to effectively strip markdown and have plain text as an output which is what I'm looking for (no need to implement another renderrer). Plus it still gives flexibility to handle some nodes in a custom way - super close to what I need