### PR TITLE
Handle bold/strong nested inside italics/em

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -163,6 +163,9 @@ func TestEmphasisMix(t *testing.T) {
 		"***triple emphasis___\n",
 		"<p>***triple emphasis___</p>\n",
 
+		"*italics **and bold** end*\n",
+		"<p><em>italics <strong>and bold</strong> end</em></p>\n",
+
 		"*__triple emphasis__*\n",
 		"<p><em><strong>triple emphasis</strong></em></p>\n",
 
@@ -173,7 +176,7 @@ func TestEmphasisMix(t *testing.T) {
 		"<p><strong>improper *nesting</strong> is* bad</p>\n",
 
 		"*improper **nesting* is** bad\n",
-		"<p>*improper <strong>nesting* is</strong> bad</p>\n",
+		"<p><em>improper **nesting</em> is** bad</p>\n",
 	}
 	doTestsInline(t, tests)
 }

--- a/inline_test.go
+++ b/inline_test.go
@@ -166,6 +166,9 @@ func TestEmphasisMix(t *testing.T) {
 		"*italics **and bold** end*\n",
 		"<p><em>italics <strong>and bold</strong> end</em></p>\n",
 
+		"*italics **and bold***\n",
+		"<p><em>italics <strong>and bold</strong></em></p>\n",
+
 		"*__triple emphasis__*\n",
 		"<p><em><strong>triple emphasis</strong></em></p>\n",
 

--- a/inline_test.go
+++ b/inline_test.go
@@ -169,6 +169,12 @@ func TestEmphasisMix(t *testing.T) {
 		"*italics **and bold***\n",
 		"<p><em>italics <strong>and bold</strong></em></p>\n",
 
+		"***bold** and italics*\n",
+		"<p><em><strong>bold</strong> and italics</em></p>\n",
+
+		"*start **bold** and italics*\n",
+		"<p><em>start <strong>bold</strong> and italics</em></p>\n",
+
 		"*__triple emphasis__*\n",
 		"<p><em><strong>triple emphasis</strong></em></p>\n",
 

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -1201,7 +1201,7 @@ func helperEmphasis(p *Parser, data []byte, c byte) (int, ast.Node) {
 		}
 
 		if i+1 < len(data) && data[i+1] == c {
-			i++
+			i += 2
 			continue
 		}
 

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -1185,9 +1185,9 @@ func helperFindEmphChar(data []byte, c byte) int {
 func helperEmphasis(p *Parser, data []byte, c byte) (int, ast.Node) {
 	i := 0
 
-	// skip one symbol if coming from emph3
+	// skip two symbols if coming from emph3, as it detected a double emphasis case
 	if len(data) > 1 && data[0] == c && data[1] == c {
-		i = 1
+		i += 2
 	}
 
 	for i < len(data) {

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -1192,9 +1192,6 @@ func helperEmphasis(p *Parser, data []byte, c byte) (int, ast.Node) {
 
 	for i < len(data) {
 		length := helperFindEmphChar(data[i:], c)
-		if length == 0 {
-			return 0, nil
-		}
 		i += length
 		if i >= len(data) {
 			return 0, nil
@@ -1216,6 +1213,11 @@ func helperEmphasis(p *Parser, data []byte, c byte) (int, ast.Node) {
 			emph := &ast.Emph{}
 			p.Inline(emph, data[:i])
 			return i + 1, emph
+		}
+
+		// We have to check this at the end, otherwise the scenario where we find repeated c's will get skipped
+		if length == 0 {
+			return 0, nil
 		}
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -727,7 +727,7 @@ func IsPunctuation(c byte) bool {
 	return false
 }
 
-// IsSpace returns true if c is a white-space charactr
+// IsSpace returns true if c is a white-space character
 func IsSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
 }


### PR DESCRIPTION
While trying out this library, my initial input ran up against some edge cases.  (It handled everything else perfectly though, which is awesome.). I decided to take a stab at fixing the bugs, which is this PR.  I've broken down every test case addition + related fix into its own commit for easy review.

Here's the summary of changes in input/output:
| Input | Output in production | Output after this PR |
| ------|---------------|-------------------|
| `*italics **and bold** end*` | `<p>*italics <strong>and bold</strong> end*</p>` | `<p><em>italics <strong>and bold</strong> end</em></p>` |
| `*italics **and bold***` | `<p>*italics <strong>and bold</strong>*</p>` | `<p><em>italics <strong>and bold</strong></em></p>` |
| `***bold** and italics*` | `<p>*<strong>bold</strong> and italics*</p>` | `<p><em><strong>bold</strong> and italics</em></p>` |
| `*start **bold** and italics*` | `<p>*start <strong>bold</strong> and italics*</p>` | `<p><em>start <strong>bold</strong> and italics</em></p>` |
| `*improper **nesting* is** bad` | `<p>*improper <strong>nesting* is</strong> bad</p>` | `<p><em>improper **nesting</em> is** bad</p>` |