### PR TITLE
Add SVG element

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -76,6 +76,7 @@ var (
 		"output":     {},
 		"progress":   {},
 		"section":    {},
+		"svg":        {},
 		"video":      {},
 	}
 )

--- a/parser/block_test.go
+++ b/parser/block_test.go
@@ -1,0 +1,53 @@
+package parser
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gomarkdown/markdown/ast"
+)
+
+// Inside HTML, no Markdown is parsed.
+func TestHtmlP(t *testing.T) {
+	input := "<p>*not emph*</p>\n"
+	p := NewWithExtensions(CommonExtensions)
+	doc := p.Parse([]byte(input))
+	var buf bytes.Buffer
+	ast.Print(&buf, doc)
+	got := buf.String()
+	exp := "HTMLBlock '<p>*not emph*</p>'\n"
+	if got != exp {
+		t.Errorf("\nInput   [%#v]\nExpected[%#v]\nGot     [%#v]\n",
+			input, exp, got)
+	}
+}
+
+// Inside SVG, so the RECT element is passed through.
+func TestSVG(t *testing.T) {
+	input := "<svg><rect> *no emph* </rect></svg>\n"
+	p := NewWithExtensions(CommonExtensions)
+	doc := p.Parse([]byte(input))
+	var buf bytes.Buffer
+	ast.Print(&buf, doc)
+	got := buf.String()
+	exp := "HTMLBlock '<svg><rect> *no emph* </rect></svg>'\n"
+	if got != exp {
+		t.Errorf("\nInput   [%#v]\nExpected[%#v]\nGot     [%#v]\n",
+			input, exp, got)
+	}
+}
+
+// The RECT element on its own is nothing special, so Markdown is parsed.
+func TestRect(t *testing.T) {
+	input := "<rect> *emph* </rect>\n"
+	p := NewWithExtensions(CommonExtensions)
+	doc := p.Parse([]byte(input))
+	var buf bytes.Buffer
+	ast.Print(&buf, doc)
+	got := buf.String()
+	exp := "Paragraph\n  Text\n  HTMLSpan '<rect>'\n  Text\n  Emph\n    Text 'emph'\n  Text\n  HTMLSpan '</rect>'\n"
+	if got != exp {
+		t.Errorf("\nInput   [%#v]\nExpected[%#v]\nGot     [%#v]\n",
+			input, exp, got)
+	}
+}


### PR DESCRIPTION
SVG is now part of HTML 5 and the SVG element a valid top-level element. The other SVG element, however, do not stand on their own. https://html.spec.whatwg.org/dev/embedded-content-other.html#svg-0

Note: This does not match up with the definition of CommonMark HTML blocks. CommonMark does not recognize the SVG element as a HTML block. In this respect, however, it would seem that CommonMark is lagging behind. https://spec.commonmark.org/0.31.2/#html-blocks