### PR TITLE
Fixed line breaks in rendered markdown output

### DIFF
--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -232,7 +232,7 @@ func (r *Renderer) codeBlock(w io.Writer, node *ast.CodeBlock) {
 	}
 	r.outs(w, "\n")
 	r.out(w, text)
-	r.outs(w, "\n```\n")
+	r.outs(w, "```\n\n")
 }
 
 func (r *Renderer) code(w io.Writer, node *ast.Code) {

--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -58,6 +58,7 @@ func (r *Renderer) list(w io.Writer, node *ast.List, entering bool) {
 		}
 	} else {
 		r.listDepth--
+		fmt.Fprintf(w, "\n")
 	}
 }
 
@@ -82,7 +83,14 @@ func (r *Renderer) listItem(w io.Writer, node *ast.ListItem, entering bool) {
 
 func (r *Renderer) para(w io.Writer, node *ast.Paragraph, entering bool) {
 	if !entering && r.lastOutputLen > 0 {
-		r.outs(w, "\n")
+		var br = "\n\n"
+
+		// List items don't need the extra line-break.
+		if _, ok := node.Parent.(*ast.ListItem); ok {
+			br = "\n"
+		}
+
+		r.outs(w, br)
 	}
 }
 
@@ -241,7 +249,7 @@ func (r *Renderer) heading(w io.Writer, node *ast.Heading, entering bool) {
 		r.outs(w, " ")
 		r.out(w, node.Literal)
 	} else {
-		r.outs(w, "\n")
+		r.outs(w, "\n\n")
 	}
 }
 

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -11,7 +11,7 @@ import (
 func TestRenderDocument(t *testing.T) {
 	var source = []byte("# title\n* aaa\n* bbb\n* ccc")
 	var input = markdown.Parse(source, nil)
-	var expected = "# title\n* aaa\n* bbb\n* ccc\n"
+	var expected = "# title\n\n* aaa\n* bbb\n* ccc\n\n"
 	testRendering(t, input, expected)
 }
 
@@ -31,7 +31,7 @@ func TestRenderStrong(t *testing.T) {
 func TestRenderHeading(t *testing.T) {
 	var input ast.Node = &ast.Heading{Level: 3}
 	ast.AppendChild(input, &ast.Text{Leaf: ast.Leaf{Literal: []byte(string("Hello"))}})
-	expected := "### Hello\n"
+	expected := "### Hello\n\n"
 	testRendering(t, input, expected)
 }
 
@@ -80,7 +80,15 @@ func TestRenderCodeBlock(t *testing.T) {
 func TestRenderParagraph(t *testing.T) {
 	var input = &ast.Paragraph{}
 	ast.AppendChild(input, &ast.Text{Leaf: ast.Leaf{Literal: []byte(string("Hello World !"))}})
-	expected := "Hello World !\n"
+	expected := "Hello World !\n\n"
+	testRendering(t, input, expected)
+}
+
+func TestRenderDoubleParagraph(t *testing.T) {
+	input := markdown.Parse([]byte("Paragraph 1\n\nParagraph 2"), nil)
+
+	expected := "Paragraph 1\n\nParagraph 2\n\n"
+
 	testRendering(t, input, expected)
 }
 
@@ -101,37 +109,37 @@ func TestRenderHTMLBlock(t *testing.T) {
 func TestRenderList(t *testing.T) {
 	var source = []byte("* aaa\n* bbb\n* ccc\n* ddd\n")
 	var input = markdown.Parse(source, nil)
-	var expected = "* aaa\n* bbb\n* ccc\n* ddd\n"
+	var expected = "* aaa\n* bbb\n* ccc\n* ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("+ aaa\n+ bbb\n+ ccc\n+ ddd\n")
 	input = markdown.Parse(source, nil)
-	expected = "+ aaa\n+ bbb\n+ ccc\n+ ddd\n"
+	expected = "+ aaa\n+ bbb\n+ ccc\n+ ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("- aaa\n- bbb\n- ccc\n- ddd\n")
 	input = markdown.Parse(source, nil)
-	expected = "- aaa\n- bbb\n- ccc\n- ddd\n"
+	expected = "- aaa\n- bbb\n- ccc\n- ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("1. aaa\n2. bbb\n3. ccc\n4. ddd\n")
 	input = markdown.Parse(source, nil)
-	expected = "1. aaa\n2. bbb\n3. ccc\n4. ddd\n"
+	expected = "1. aaa\n2. bbb\n3. ccc\n4. ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("1. aaa\n1. bbb\n1. ccc\n1. ddd\n")
 	input = markdown.Parse(source, nil)
-	expected = "1. aaa\n2. bbb\n3. ccc\n4. ddd\n"
+	expected = "1. aaa\n2. bbb\n3. ccc\n4. ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("1. aaa\n3. bbb\n8. ccc\n1. ddd\n")
 	input = markdown.Parse(source, nil)
-	expected = "1. aaa\n2. bbb\n3. ccc\n4. ddd\n"
+	expected = "1. aaa\n2. bbb\n3. ccc\n4. ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("* aaa\n    * aaa1\n    * aaa2\n* bbb\n* ccc\n* ddd\n")
 	input = markdown.Parse(source, nil)
-	expected = "* aaa\n    * aaa1\n    * aaa2\n* bbb\n* ccc\n* ddd\n"
+	expected = "* aaa\n    * aaa1\n    * aaa2\n\n* bbb\n* ccc\n* ddd\n\n"
 	testRendering(t, input, expected)
 }
 

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -92,6 +92,14 @@ func TestRenderDoubleParagraph(t *testing.T) {
 	testRendering(t, input, expected)
 }
 
+func TestRenderCodeWithParagraph(t *testing.T) {
+	input := markdown.Parse([]byte("```\nnpm run build\nnpm run test:e2e:dev\n```"), nil)
+
+	expected := "\n```\nnpm run build\nnpm run test:e2e:dev\n```\n\n"
+
+	testRendering(t, input, expected)
+}
+
 func TestRenderHTMLSpan(t *testing.T) {
 	var input = &ast.HTMLSpan{}
 	input.Literal = []byte(string("hello"))


### PR DESCRIPTION
This PR fixes line breaks in the output of the markdown renderer.

Currently, if a markdown document is parsed and rendered using this `markdown` library, some relevant line breaks are lost:

- double line breaks after paragraphs

There are other (cosmetic) line breaks that are lost, but don't affect the validity of the markdown output:

- line breaks after headings
- line breaks after lists

There are some line-breaks that are added that should not be added:

- A new line at the end of code blocks is added. 

#### Example

Input:

```md
# heading

Paragraph 1

Paragraph 2

- List item 1
- List item 2

Paragraph 3

\```
some code
\```
```

Is currently rendered as:


```md
# heading
Paragraph 1
Paragraph 2
- List item 1
- List item 2
Paragraph 3
\```
some code

\```
```

<details>

```go
func TestPR(t *testing.T) {
	input := markdown.Parse([]byte(`
# heading

Paragraph 1

Paragraph 2

- List item

Paragraph 3
`), nil)

	fmt.Println(string(markdown.Render(input, NewRenderer())))
}
```

</details>

Note that paragraphs 1 and 2 are now no longer two separate paragraphs. It is also common to add double line breaks after a list and a heading for better readability.


This PR ensures, that there are always two line breaks after a heading, a paragraph or a list.