### PR TITLE
Make parser.InsideLink public

### DIFF
--- a/parser/inline.go
+++ b/parser/inline.go
@@ -271,7 +271,7 @@ func maybeInlineFootnoteOrSuper(p *Parser, data []byte, offset int) (int, ast.No
 // '[': parse a link or an image or a footnote or a citation
 func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 	// no links allowed inside regular links, footnote, and deferred footnotes
-	if p.insideLink && (offset > 0 && data[offset-1] == '[' || len(data)-1 > offset && data[offset+1] == '^') {
+	if p.InsideLink && (offset > 0 && data[offset-1] == '[' || len(data)-1 > offset && data[offset+1] == '^') {
 		return 0, nil
 	}
 
@@ -622,10 +622,10 @@ func link(p *Parser, data []byte, offset int) (int, ast.Node) {
 		} else {
 			// links cannot contain other links, so turn off link parsing
 			// temporarily and recurse
-			insideLink := p.insideLink
-			p.insideLink = true
+			InsideLink := p.InsideLink
+			p.InsideLink = true
 			p.Inline(link, data[1:txtE])
-			p.insideLink = insideLink
+			p.InsideLink = InsideLink
 		}
 		return i, link
 
@@ -860,7 +860,7 @@ const shortestPrefix = 6 // len("ftp://"), the shortest of the above
 
 func maybeAutoLink(p *Parser, data []byte, offset int) (int, ast.Node) {
 	// quick check to rule out most false hits
-	if p.insideLink || len(data) < offset+shortestPrefix {
+	if p.InsideLink || len(data) < offset+shortestPrefix {
 		return 0, nil
 	}
 	for _, prefix := range protocolPrefixes {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -103,7 +103,7 @@ type Parser struct {
 	inlineCallback [256]InlineParser
 	nesting        int
 	maxNesting     int
-	insideLink     bool
+	InsideLink     bool
 	indexCnt       int // incremented after every index
 
 	// Footnotes need to be ordered as well as available to quickly check for
@@ -143,7 +143,7 @@ func NewWithExtensions(extension Extensions) *Parser {
 		refs:         make(map[string]*reference),
 		refsRecord:   make(map[string]struct{}),
 		maxNesting:   64,
-		insideLink:   false,
+		InsideLink:   false,
 		Doc:          &ast.Document{},
 		extensions:   extension,
 		allClosed:    true,


### PR DESCRIPTION
I have added hashtags to my Markdown. When rendered, these produce a search link. My problem was that sometimes the link text contained something that looked like a hashtag. Specifically: `[oh #ok](ok)` should produce `<a href="ok">oh #ok</a></p>` and not `<a href="ok">oh <a class="tag" href="/search/?q=%23ok">#ok</a></a></p>`.

I can fix this if `p.InsideLink` is accessible to my code:

```go
// hashtag returns an inline parser function. This indirection is
// required because we want to receive an array of hashtags found.
// The hashtags in the array keep their case.
func hashtag() (func(p *parser.Parser, data []byte, offset int) (int, ast.Node), *[]string) {
	hashtags := make([]string, 0)
	return func(p *parser.Parser, data []byte, offset int) (int, ast.Node) {
		if p.InsideLink { // HERE
			return 0, nil
		}
		data = data[offset:]
		i := 0
		n := len(data)
		for i < n && !parser.IsSpace(data[i]) {
			i++
		}
		if i <= 1 {
			return 0, nil
		}
		hashtags = append(hashtags, string(data[1:i]))
		link := &ast.Link{
			AdditionalAttributes: []string{`class="tag"`},
			Destination:          append([]byte("/search/?q=%23"), data[1:i]...),
		}
		text := bytes.ReplaceAll(data[0:i], []byte("_"), []byte(" "))
		ast.AppendChild(link, &ast.Text{Leaf: ast.Leaf{Literal: text}})
		return i, link
	}, &hashtags
}
```
