### PR TITLE
Fix the example so that it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ To convert markdown text to HTML using reasonable defaults:
 package main
 
 import (
-	"os"
-
 	"github.com/gomarkdown/markdown"
-	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/html"
 	"github.com/gomarkdown/markdown/parser"
 


### PR DESCRIPTION
Thank you for this project! I've always went straight to your docs, but today I started a new project and I tried copy/pasting the example.  When running with `go run` I noticed that both os and markdown/ast are imported and unused.

```
$ go run main.go
# command-line-arguments
./main.go:4:2: "os" imported and not used
./main.go:7:2: "github.com/gomarkdown/markdown/ast" imported and not used
```