### PR TITLE
Add flag to render link definitions in footer

### DIFF
--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -318,18 +318,20 @@ func (r *Renderer) link(w io.Writer, node *ast.Link, entering bool) {
 				r.outs(w, `"`)
 			}
 			r.outs(w, ")")
-		} else {
-			r.outs(w, "]")
-			child, _ := ast.GetFirstChild(node).(*ast.Text)
-			linkdefn := fmt.Sprintf("[%s]: %s", string(escape(child.Leaf.Literal)), link)
-			if len(title) != 0 {
-				linkdefn += fmt.Sprintf(" \"%s\"", title)
-			}
-			if r.linkcache == nil {
-				r.linkcache = make(map[string]bool)
-			}
-			r.linkcache[linkdefn] = true
+			return
 		}
+
+		r.outs(w, "]")
+		child, _ := ast.GetFirstChild(node).(*ast.Text)
+		linkdefn := fmt.Sprintf("[%s]: %s", string(escape(child.Leaf.Literal)), link)
+		if len(title) != 0 {
+			linkdefn += fmt.Sprintf(" \"%s\"", title)
+		}
+		if r.linkcache == nil {
+			r.linkcache = make(map[string]bool)
+		}
+		r.linkcache[linkdefn] = true
+
 	}
 }
 

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -149,26 +149,16 @@ func TestRenderList(t *testing.T) {
 	input = markdown.Parse(source, nil)
 	expected = "* aaa\n    * aaa1\n    * aaa2\n\n* bbb\n* ccc\n* ddd\n\n"
 	testRendering(t, input, expected)
+
+	source = []byte("This is an [example](https://example.com) and another [website](https://github.com).")
+	input = markdown.Parse(source, nil)
+	rendererOpts := []RendererOpt{WithRenderInFooter(true)}
+	expected = "This is an [example] and another [website].\n\n\n[example]: https://example.com\n[website]: https://github.com\n"
+	testRendering(t, input, expected, rendererOpts...)
 }
 
-func testRendering(t *testing.T, input ast.Node, expected string) {
-	renderer := NewRenderer()
-	result := string(markdown.Render(input, renderer))
-	if strings.Compare(result, expected) != 0 {
-		t.Errorf("[%s] is not equal to [%s]", result, expected)
-	}
-}
-
-func TestRenderLinksInFooter(t *testing.T) {
-	source := []byte("This is an [example](https://example.com) and another [website](https://github.com).")
-	input := markdown.Parse(source, nil)
-	flags := renderLinksInFooter
-	expected := "This is an [example] and another [website].\n\n\n[example]: https://example.com\n[website]: https://github.com\n"
-	testRenderingWithFlags(t, input, expected, flags)
-}
-
-func testRenderingWithFlags(t *testing.T, input ast.Node, expected string, flags Flags) {
-	renderer := NewRenderer(WithRenderInFooter(true))
+func testRendering(t *testing.T, input ast.Node, expected string, opts ...RendererOpt) {
+	renderer := NewRenderer(opts...)
 	result := string(markdown.Render(input, renderer))
 	if strings.Compare(result, expected) != 0 {
 		t.Errorf("[%s] is not equal to [%s]", result, expected)

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestRenderDocument(t *testing.T) {
-	var source = []byte("# title\n* aaa\n* bbb\n* ccc")
-	var input = markdown.Parse(source, nil)
-	var expected = "# title\n\n* aaa\n* bbb\n* ccc\n\n"
+	source := []byte("# title\n* aaa\n* bbb\n* ccc")
+	input := markdown.Parse(source, nil)
+	expected := "# title\n\n* aaa\n* bbb\n* ccc\n\n"
 	testRendering(t, input, expected)
 }
 
@@ -64,21 +64,21 @@ func TestRenderImage(t *testing.T) {
 }
 
 func TestRenderCode(t *testing.T) {
-	var input = &ast.Code{}
+	input := &ast.Code{}
 	input.Literal = []byte(string("val x : Int = 42"))
 	expected := "`val x : Int = 42`"
 	testRendering(t, input, expected)
 }
 
 func TestRenderCodeBlock(t *testing.T) {
-	var input = &ast.CodeBlock{Info: []byte(string("scala"))}
+	input := &ast.CodeBlock{Info: []byte(string("scala"))}
 	input.Literal = []byte(string("val x : Int = 42"))
 	expected := "\n```scala\nval x : Int = 42\n```\n"
 	testRendering(t, input, expected)
 }
 
 func TestRenderParagraph(t *testing.T) {
-	var input = &ast.Paragraph{}
+	input := &ast.Paragraph{}
 	ast.AppendChild(input, &ast.Text{Leaf: ast.Leaf{Literal: []byte(string("Hello World !"))}})
 	expected := "Hello World !\n\n"
 	testRendering(t, input, expected)
@@ -101,23 +101,23 @@ func TestRenderCodeWithParagraph(t *testing.T) {
 }
 
 func TestRenderHTMLSpan(t *testing.T) {
-	var input = &ast.HTMLSpan{}
+	input := &ast.HTMLSpan{}
 	input.Literal = []byte(string("hello"))
 	expected := "hello"
 	testRendering(t, input, expected)
 }
 
 func TestRenderHTMLBlock(t *testing.T) {
-	var input = &ast.HTMLBlock{}
+	input := &ast.HTMLBlock{}
 	input.Literal = []byte(string("hello"))
 	expected := "\nhello\n\n"
 	testRendering(t, input, expected)
 }
 
 func TestRenderList(t *testing.T) {
-	var source = []byte("* aaa\n* bbb\n* ccc\n* ddd\n")
-	var input = markdown.Parse(source, nil)
-	var expected = "* aaa\n* bbb\n* ccc\n* ddd\n\n"
+	source := []byte("* aaa\n* bbb\n* ccc\n* ddd\n")
+	input := markdown.Parse(source, nil)
+	expected := "* aaa\n* bbb\n* ccc\n* ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("+ aaa\n+ bbb\n+ ccc\n+ ddd\n")
@@ -153,6 +153,23 @@ func TestRenderList(t *testing.T) {
 
 func testRendering(t *testing.T, input ast.Node, expected string) {
 	renderer := NewRenderer()
+	result := string(markdown.Render(input, renderer))
+	if strings.Compare(result, expected) != 0 {
+		t.Errorf("[%s] is not equal to [%s]", result, expected)
+	}
+}
+
+func TestRenderLinksInFooter(t *testing.T) {
+	source := []byte("This is an [example](https://example.com) and another [website](https://github.com).")
+	input := markdown.Parse(source, nil)
+	flags := renderLinksInFooter
+	expected := "This is an [example] and another [website].\n\n\n[example]: https://example.com\n[website]: https://github.com\n"
+	testRenderingWithFlags(t, input, expected, flags)
+}
+
+func testRenderingWithFlags(t *testing.T, input ast.Node, expected string, flags Flags) {
+	renderer := NewRenderer()
+	renderer.WithOpts(&RendererOptions{Flags: flags})
 	result := string(markdown.Render(input, renderer))
 	if strings.Compare(result, expected) != 0 {
 		t.Errorf("[%s] is not equal to [%s]", result, expected)

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -168,8 +168,7 @@ func TestRenderLinksInFooter(t *testing.T) {
 }
 
 func testRenderingWithFlags(t *testing.T, input ast.Node, expected string, flags Flags) {
-	renderer := NewRenderer()
-	renderer.WithOpts(&RendererOptions{Flags: flags})
+	renderer := NewRenderer(WithRenderInFooter(true))
 	result := string(markdown.Render(input, renderer))
 	if strings.Compare(result, expected) != 0 {
 		t.Errorf("[%s] is not equal to [%s]", result, expected)


### PR DESCRIPTION
Add a flag for the markdown renderer, renderLinksInFooter, that can be used to render link definitions in the footer of the document, rather than inline.

Example usage:

renderer := NewRenderer()
renderer.WithOpts(&RendererOptions{Flags: flags})
result := markdown.Render(input, renderer)

Example input: 
"This is an [example](https://example.com) and another [website](https://github.com)."
Example output: 
"This is an [example] and another [website].


[example]: https://example.com
[website]: https://github.com
"