### PR TITLE
Fix extra newlines in sub-lists in markdown renderer

### DIFF
--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -88,7 +88,9 @@ func (r *Renderer) list(w io.Writer, node *ast.List, entering bool) {
 		}
 	} else {
 		r.listDepth--
-		fmt.Fprintf(w, "\n")
+		if _, ok := node.Parent.(*ast.ListItem); !ok {
+			fmt.Fprintf(w, "\n")
+		}
 	}
 }
 

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -150,6 +150,26 @@ func TestRenderList(t *testing.T) {
 	expected = "* aaa\n    * aaa1\n    * aaa2\n\n* bbb\n* ccc\n* ddd\n\n"
 	testRendering(t, input, expected)
 
+	source = []byte("* aaa\n    * aaa1\n\n")
+	input = markdown.Parse(source, nil)
+	expected = "* aaa\n    * aaa1\n\n"
+	testRendering(t, input, expected)
+
+	source = []byte("* aaa\n    * aaa1\n        * aaa1.1\n\n")
+	input = markdown.Parse(source, nil)
+	expected = "* aaa\n    * aaa1\n        * aaa1.1\n\n"
+	testRendering(t, input, expected)
+
+	source = []byte("1. aaa\n    1. aaa1\n\n")
+	input = markdown.Parse(source, nil)
+	expected = "1. aaa\n    1. aaa1\n\n"
+	testRendering(t, input, expected)
+
+	source = []byte("1. aaa\n    1. aaa1\n        1. aaa1.1\n\n")
+	input = markdown.Parse(source, nil)
+	expected = "1. aaa\n    1. aaa1\n        1. aaa1.1\n\n"
+	testRendering(t, input, expected)
+
 	source = []byte("This is an [example](https://example.com) and another [website](https://github.com).")
 	input = markdown.Parse(source, nil)
 	rendererOpts := []RendererOpt{WithRenderInFooter(true)}

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -147,7 +147,7 @@ func TestRenderList(t *testing.T) {
 
 	source = []byte("* aaa\n    * aaa1\n    * aaa2\n* bbb\n* ccc\n* ddd\n")
 	input = markdown.Parse(source, nil)
-	expected = "* aaa\n    * aaa1\n    * aaa2\n\n* bbb\n* ccc\n* ddd\n\n"
+	expected = "* aaa\n    * aaa1\n    * aaa2\n* bbb\n* ccc\n* ddd\n\n"
 	testRendering(t, input, expected)
 
 	source = []byte("* aaa\n    * aaa1\n\n")


### PR DESCRIPTION
Fix how sub-lists within a list are rendered by the markdown renderer - don't insert an extra newline after the sub-list.

Resolves https://github.com/gomarkdown/markdown/issues/339 and https://github.com/gomarkdown/markdown/issues/340.