### PR TITLE
fix: skip empty citation segments after semicolon split

### DIFF
--- a/parser/citation.go
+++ b/parser/citation.go
@@ -49,6 +49,9 @@ func citation(p *Parser, data []byte, offset int) (int, ast.Node) {
 	for _, citation := range citations {
 		var suffix []byte
 		citation = bytes.TrimSpace(citation)
+		if len(citation) == 0 {
+			continue
+		}
 		j := 0
 		if citation[j] != '@' {
 			// not a citation, drop out entirely.

--- a/parser/citation_test.go
+++ b/parser/citation_test.go
@@ -43,6 +43,23 @@ func TestCitationSuffix(t *testing.T) {
 	}
 }
 
+func TestCitationEmptySegment(t *testing.T) {
+	p := New()
+	p.extensions |= Mmark
+
+	// These inputs should not panic
+	inputs := [][]byte{
+		[]byte(`[@;]`),
+		[]byte(`[@ref;]`),
+		[]byte(`[@ref1;;@ref2]`),
+	}
+	for _, data := range inputs {
+		_, node := citation(p, data, 0)
+		// empty segments are skipped; result depends on remaining valid citations
+		_ = node
+	}
+}
+
 func TestCitationSuffixMultiple(t *testing.T) {
 	data := []byte(`[@?RFC1034; @!RFC1035, p. 144, more]`)
 


### PR DESCRIPTION
Fixes #348.

`citation()` panics when `bytes.Split` produces empty segments from adjacent or trailing semicolons in citation syntax (e.g. `[@;]`, `[@ref;]`, `[@ref1;;@ref2]`).

### What changed

- `parser/citation.go`: added `len(citation) == 0` check with `continue` after `TrimSpace`, before indexing into the slice
- `parser/citation_test.go`: added `TestCitationEmptySegment` covering the three panic cases

Using `continue` preserves valid citations on either side of an empty segment.