### PR TITLE
fix: check IndexByte return before adding in tagLength

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -1286,6 +1286,14 @@ func TestSkipHTML(t *testing.T) {
 	}, TestParams{Flags: html.SkipHTML})
 }
 
+func TestTagLengthUnclosedAngle(t *testing.T) {
+	// Unclosed angle brackets with short tag names should not lose content
+	doTestsParam(t, []string{
+		"click <a href content",
+		"<p>click &lt;a href content</p>\n",
+	}, TestParams{Flags: html.SkipHTML})
+}
+
 func TestInlineMath(t *testing.T) {
 	doTestsParam(t, []string{
 		"$a_b$",

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -1073,10 +1073,11 @@ func tagLength(data []byte) (autolink autolinkType, end int) {
 		// one of the forbidden chars has been found
 		autolink = notAutolink
 	}
-	i += bytes.IndexByte(data[i:], '>')
-	if i < 0 {
+	j = bytes.IndexByte(data[i:], '>')
+	if j < 0 {
 		return autolink, 0
 	}
+	i += j
 	return autolink, i + 1
 }
 


### PR DESCRIPTION
Fixes #350.

`tagLength()` adds the `bytes.IndexByte` return value directly to `i`. When `>` is not found, the -1 return decrements `i` instead of making it negative, so the `if i < 0` guard never triggers. This causes `leftAngle()` to silently skip characters.

### What changed

- `parser/inline.go`: store `IndexByte` result in `j`, check for -1 before adding to `i`
- `inline_test.go`: added `TestTagLengthUnclosedAngle` verifying that unclosed angle brackets with short tag names preserve content