### PR TITLE
fix: replace invalid codepoints with U+FFFD in entity parser

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -1325,3 +1325,11 @@ func BenchmarkSmartDoubleQuotes(b *testing.B) {
 		runMarkdown("this should be normal \"quoted\" text.\n", params)
 	}
 }
+
+func TestEntityNullByte(t *testing.T) {
+	// &#0; should produce U+FFFD per CommonMark spec section 6.2
+	doTestsInlineParam(t, []string{
+		"&#0;",
+		"<p>\uFFFD</p>\n",
+	}, TestParams{})
+}

--- a/parser/inline.go
+++ b/parser/inline.go
@@ -817,7 +817,12 @@ func entity(p *Parser, data []byte, offset int) (int, ast.Node) {
 		codepoint, err = strconv.ParseUint(string(ent[2:len(ent)-1]), 10, 64)
 	}
 	if err == nil { // only if conversion was valid return here.
-		return end, newTextNode([]byte(string(rune(codepoint))))
+		r := rune(codepoint)
+		// Replace invalid codepoints with U+FFFD per CommonMark spec section 6.2
+		if r == 0 || (r >= 0xD800 && r <= 0xDFFF) || r > 0x10FFFF {
+			r = '\uFFFD'
+		}
+		return end, newTextNode([]byte(string(r)))
 	}
 
 	return end, newTextNode(ent)


### PR DESCRIPTION
Fixes #352.

`entity()` converts numeric character references to runes without checking for invalid codepoints. `&#0;` produces a null byte, surrogates produce invalid UTF-8, and values above 0x10FFFF are silently truncated.

### What changed

- `parser/inline.go`: added a guard for the three invalid codepoint categories (0, surrogates, >0x10FFFF) that substitutes U+FFFD per CommonMark spec section 6.2
- `inline_test.go`: added `TestEntityNullByte` verifying `&#0;` produces U+FFFD