### PR TITLE
fix: track fenced code state inside list items

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -179,6 +179,12 @@ func TestCodeInList(t *testing.T) {
 	doTestsParam(t, tests, TestParams{extensions: exts})
 }
 
+func TestBug346(t *testing.T) {
+	tests := readTestFile2(t, "bug346.tests")
+	exts := parser.CommonExtensions
+	doTestsParam(t, tests, TestParams{extensions: exts})
+}
+
 func TestLists(t *testing.T) {
 	tests := readTestFile2(t, "Lists.tests")
 	exts := parser.CommonExtensions

--- a/testdata/bug346.tests
+++ b/testdata/bug346.tests
@@ -1,0 +1,86 @@
+- test1
+
+    ```
+    - test
+    ```
+- test2
+
+    ```
+      - test
+    ```
+- test3
+
+    ```
+        - test
+    ```
++++
+<ul>
+<li><p>test1</p>
+
+<pre><code>- test
+</code></pre></li>
+
+<li><p>test2</p>
+
+<pre><code>  - test
+</code></pre></li>
+
+<li><p>test3</p>
+
+<pre><code>    - test
+</code></pre></li>
+</ul>
++++
+- item
+
+    ```
+    1. not a list
+    ```
++++
+<ul>
+<li><p>item</p>
+
+<pre><code>1. not a list
+</code></pre></li>
+</ul>
++++
+- item
+
+    ```
+    # not a heading
+    ```
++++
+<ul>
+<li><p>item</p>
+
+<pre><code># not a heading
+</code></pre></li>
+</ul>
++++
+- item
+
+    ~~~
+    - dash in tilde fence
+    ~~~
++++
+<ul>
+<li><p>item</p>
+
+<pre><code>- dash in tilde fence
+</code></pre></li>
+</ul>
++++
+- item1
+
+    ```
+    - should be code
+- item2
++++
+<ul>
+<li><p>item1</p>
+
+<p>```
+- should be code</p></li>
+
+<li><p>item2</p></li>
+</ul>


### PR DESCRIPTION
`listItem()` gatherlines loop doesn't track fenced code state, so `- content` inside a fence gets picked up as a new list item. Fix: track fence state inside the loop. Only indented fences count (at indent 0, fence ends the list). Abandon fence on non-indented lines so unclosed fences don't swallow later items.

5 tests covering dash content, ordered list, heading, tilde fences, and unclosed fence. `go test ./...` passes.

Fixes #346