### PR TITLE
fix: handle nested emphasis in triple-char closers

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -15,6 +15,20 @@ func TestEmphasis(t *testing.T) {
 	doTestsInlineParam(t, tests, TestParams{})
 }
 
+func TestBug279(t *testing.T) {
+	var tests = []string{
+		"**bold *ital***\n",
+		"<p><strong>bold <em>ital</em></strong></p>\n",
+		"**bold *ital* more**\n",
+		"<p><strong>bold <em>ital</em> more</strong></p>\n",
+		"*ital **bold***\n",
+		"<p><em>ital <strong>bold</strong></em></p>\n",
+		"**no inner star**\n",
+		"<p><strong>no inner star</strong></p>\n",
+	}
+	doTestsInlineParam(t, tests, TestParams{})
+}
+
 func TestBug309(t *testing.T) {
 	var tests = []string{
 		`*f*—`,


### PR DESCRIPTION
`helperDoubleEmphasis` consumes `***` as `**`, leaving the inner `*` unpaired. Fix shifts the content boundary to include it when the last `*` in content is an unmatched opener. `hasTrailingEmphOpener` checks only the last `*` -- checking earlier ones would flag balanced pairs incorrectly. This is a targeted fix for the `**bold *ital***` pattern, not a full overhaul of emphasis delimiter handling. Babelmark confirms the expected output: https://babelmark.github.io/?text=**bold+*ital***

4 tests: unclosed inner emph, balanced inner (regression guard), reversed nesting, no inner star. `go test ./...` passes.

Fixes #279