### PR TITLE
md: emit newline before closing fence in codeBlock

### DIFF
--- a/md/md_renderer.go
+++ b/md/md_renderer.go
@@ -264,6 +264,9 @@ func (r *Renderer) codeBlock(w io.Writer, node *ast.CodeBlock) {
 	}
 	r.outs(w, "\n")
 	r.out(w, text)
+	if len(text) == 0 || text[len(text)-1] != '\n' {
+		r.outs(w, "\n")
+	}
 	r.outs(w, "```\n\n")
 }
 

--- a/md/md_renderer_test.go
+++ b/md/md_renderer_test.go
@@ -73,7 +73,7 @@ func TestRenderCode(t *testing.T) {
 func TestRenderCodeBlock(t *testing.T) {
 	input := &ast.CodeBlock{Info: []byte(string("scala"))}
 	input.Literal = []byte(string("val x : Int = 42"))
-	expected := "\n```scala\nval x : Int = 42\n```\n"
+	expected := "\n```scala\nval x : Int = 42\n```\n\n"
 	testRendering(t, input, expected)
 }
 


### PR DESCRIPTION
Fixes #357.

## Summary

- `md.Renderer.codeBlock` used to write the closing `` ``` `` fence directly after the node literal. If the `CodeBlock.Literal` did not already end with `\n` (e.g. when the AST was constructed manually), the result was malformed markdown with the closing fence glued to the last content line. `TestRenderCodeBlock` exercised exactly this case and has been failing as a result — it was only hidden because the CI workflow runs `go test` on `.`, `./ast`, `./parser`, `./html` and not on `./md`.
- Emit `\n` before the closing fence when the literal does not already end with one. Literals produced by the parser end with a newline, so `TestRenderCodeWithParagraph` and other parser-driven tests are unaffected.
- Update `TestRenderCodeBlock`'s expected string to end with `\n\n` (matching the `doubleSpace` + closing-block semantics used by every other test in the file).

See #357 for the full reproduction and root-cause analysis.

## Test plan

- [x] `go test -v ./md` — 16/16 pass (previously 15/16)
- [x] `go test ./...` — all previously passing packages still pass; `examples/` still fails to build for an unrelated reason (missing `github.com/alecthomas/chroma/styles` module)