### PR TITLE
docs: drop the dead Try it online link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ func main() {
 }
 ```
 
-Try it online: https://onlinetool.io/goplayground/#txO7hJ-ibeU
-
 For more documentation read [this guide](https://blog.kowalczyk.info/article/cxn3/advanced-markdown-processing-in-go.html)
 
 Comparing to other markdown parsers: https://babelmark.github.io/


### PR DESCRIPTION
Closes #359.

The \`onlinetool.io/goplayground\` share link returns a 404 / unrelated page, so users following the README end up somewhere confusing. Remove the line rather than swap in another guess; the README still has a runnable example just above and links to the long-form guide right below.