### PR TITLE
parser: fix index-out-of-range panic in tableRow on whitespace-only table cell

### DIFF
--- a/fuzz_crashes_test.go
+++ b/fuzz_crashes_test.go
@@ -85,3 +85,17 @@ func TestGHSA_cv23_7vc5_jfh7_SafelinkEmptyDestination(t *testing.T) {
 		})
 	}
 }
+
+// tableRow indexed data[i] after skipChar advanced i to len(data) on a row
+// whose cell is only whitespace, panicking with index out of range.
+func TestTableRowTrailingSpaceCrasher(t *testing.T) {
+	inputs := []string{
+		" -|\n| ",
+		"a|b\n-|-\n| ",
+		" -|\n|  \t",
+	}
+	for _, input := range inputs {
+		// Must not panic (Tables is enabled via the default CommonExtensions).
+		_ = ToHTML([]byte(input), nil, nil)
+	}
+}

--- a/parser/block_table.go
+++ b/parser/block_table.go
@@ -26,7 +26,7 @@ func (p *Parser) tableRow(data []byte, columns []ast.CellAlignFlags, header bool
 		cellStart := i
 
 		// If we are in a codespan we should discount any | we see, check for that here and skip ahead.
-		if data[i] == '`' {
+		if i < n && data[i] == '`' {
 			if isCode, _ := codeSpan(p, data[i:], 0); isCode > 0 {
 				i += isCode - 1
 			}


### PR DESCRIPTION
A crafted table row whose cell contains only whitespace makes `Parse`/`ToHTML` panic with an `index out of range`, since Tables is enabled by the default `CommonExtensions` so this is reachable straight from the top-level entry points on untrusted markdown.

**Failure mode**

In `parser.(*Parser).tableRow`, each cell iteration does `i = skipChar(data, i, ' ')` and then immediately reads `data[i]` to check for a codespan backtick:

```go
i = skipChar(data, i, ' ')
cellStart := i
if data[i] == '`' { // panics when i == len(data)
```

When the trailing cell is only spaces, `skipChar` advances `i` to `len(data)`, and the unguarded `data[i]` panics. Every other read in the loop is already guarded by `i < n`; this one was missed.

**Repro**

```go
markdown.ToHTML([]byte(" -|\n| "), nil, nil)
// panic: runtime error: index out of range [2] with length 2
```

**Fix**

Guard the backtick check with `i < n`, matching the bounds checks used throughout the rest of the loop. Valid tables are unaffected (the guard only skips a read that would have been out of bounds anyway).

**Tests**

Added `TestTableRowTrailingSpaceCrasher` to `fuzz_crashes_test.go` covering several whitespace-only-cell rows. It panics before the change and passes after. Full `go test ./...`, `go vet ./...`, and `gofmt` are clean, and a short native fuzz run over the table path surfaced no further crashers.